### PR TITLE
Idiomatic fixes 2

### DIFF
--- a/src/cd.rs
+++ b/src/cd.rs
@@ -158,7 +158,7 @@ pub(crate) fn alpha_unicode_split(decoded_sequence: &str) -> Vec<String> {
 
             let layer = layers
                 .entry(layer_target_range.unwrap())
-                .or_insert(String::from(""));
+                .or_insert_with(String::new);
             *layer += &ch.to_lowercase().to_string();
         }
     }

--- a/src/cd.rs
+++ b/src/cd.rs
@@ -154,9 +154,7 @@ pub(crate) fn alpha_unicode_split(decoded_sequence: &str) -> Vec<String> {
                     break;
                 }
             }
-            if layer_target_range.is_none() {
-                layer_target_range = Some(character_range);
-            }
+            layer_target_range.get_or_insert(character_range);
 
             let layer = layers
                 .entry(layer_target_range.unwrap())

--- a/src/cd.rs
+++ b/src/cd.rs
@@ -252,7 +252,7 @@ pub(crate) fn coherence_ratio(
         };
 
         let popular_character_ordered_as_string: String =
-            popular_character_ordered.clone().iter().copied().collect();
+            popular_character_ordered.iter().copied().collect();
 
         // Convert the String into a &str
         for language in languages {

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -361,9 +361,6 @@ impl CharsetMatches {
     }
     // Simply return the first match. Strict equivalent to matches[0].
     pub fn get_best(&self) -> Option<&CharsetMatch> {
-        if self.items.is_empty() {
-            return None;
-        }
         self.items.first()
     }
     // Retrieve a single item either by its position or encoding name (alias may be used here).

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -203,10 +203,8 @@ impl CharsetMatch {
         }
         vec![]
     }
+    // byte_order_mark
     pub fn bom(&self) -> bool {
-        self.has_sig_or_bom
-    }
-    pub fn byte_order_mark(&self) -> bool {
         self.has_sig_or_bom
     }
     pub fn encoding(&self) -> &str {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,8 +135,8 @@ use crate::consts::{IANA_SUPPORTED, MAX_PROCESSED_BYTES, TOO_BIG_SEQUENCE, TOO_S
 use crate::entity::{CharsetMatch, CharsetMatches, CoherenceMatches, NormalizerSettings};
 use crate::md::mess_ratio;
 use crate::utils::{
-    any_specified_encoding, decode, iana_name, identify_sig_or_bom,
-    is_cp_similar, is_multi_byte_encoding, round_float, should_strip_sig_or_bom,
+    any_specified_encoding, decode, iana_name, identify_sig_or_bom, is_cp_similar,
+    is_multi_byte_encoding, round_float, should_strip_sig_or_bom,
 };
 use encoding::DecoderTrap;
 use log::{debug, trace};
@@ -416,7 +416,13 @@ pub fn from_bytes(bytes: &Vec<u8>, settings: Option<NormalizerSettings>) -> Char
                     &[]
                 };
                 let cut_bytes_slice = &[cut_bytes_vec, &bytes[offset..offset_end]].concat();
-                decode(cut_bytes_slice, encoding_iana, DecoderTrap::Strict, false, false)
+                decode(
+                    cut_bytes_slice,
+                    encoding_iana,
+                    DecoderTrap::Strict,
+                    false,
+                    false,
+                )
             };
 
             // ascii in encodings means windows-1252 codepage with supports diacritis

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -569,7 +569,7 @@ pub fn from_bytes(bytes: &Vec<u8>, settings: Option<NormalizerSettings>) -> Char
         ));
 
         if (mean_mess_ratio < 0.1 && prioritized_encodings.contains(&encoding_iana.to_string()))
-            || encoding_iana == sig_encoding.clone().unwrap_or(String::new())
+            || encoding_iana == sig_encoding.clone().unwrap_or_default()
         {
             debug!(
                 "Encoding detection: {} is most likely the one.",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ use crate::consts::{IANA_SUPPORTED, MAX_PROCESSED_BYTES, TOO_BIG_SEQUENCE, TOO_S
 use crate::entity::{CharsetMatch, CharsetMatches, CoherenceMatches, NormalizerSettings};
 use crate::md::mess_ratio;
 use crate::utils::{
-    any_specified_encoding, concatenate_slices, decode, iana_name, identify_sig_or_bom,
+    any_specified_encoding, decode, iana_name, identify_sig_or_bom,
     is_cp_similar, is_multi_byte_encoding, round_float, should_strip_sig_or_bom,
 };
 use encoding::DecoderTrap;
@@ -415,9 +415,8 @@ pub fn from_bytes(bytes: &Vec<u8>, settings: Option<NormalizerSettings>) -> Char
                 } else {
                     &[]
                 };
-                let cut_bytes_vec = concatenate_slices(cut_bytes_vec, &bytes[offset..offset_end]);
-                let cut_bytes = cut_bytes_vec.as_slice();
-                decode(cut_bytes, encoding_iana, DecoderTrap::Strict, false, false)
+                let cut_bytes_slice = &[cut_bytes_vec, &bytes[offset..offset_end]].concat();
+                decode(cut_bytes_slice, encoding_iana, DecoderTrap::Strict, false, false)
             };
 
             // ascii in encodings means windows-1252 codepage with supports diacritis

--- a/src/md.rs
+++ b/src/md.rs
@@ -485,12 +485,10 @@ pub(crate) fn mess_ratio(
 
     let length = decoded_sequence.chars().count() + 1;
     let mut mean_mess_ratio: f32 = 0.0;
-    let intermediary_mean_mess_ratio_calc: u64 = if length < 512 {
-        32
-    } else if length <= 1024 {
-        64
-    } else {
-        128
+    let intermediary_mean_mess_ratio_calc: u64 = match length {
+        0..=511 => 32,
+        512..=1024 => 64,
+        _ => 128,
     };
     let new_sequence = decoded_sequence.to_string() + "\n";
 

--- a/src/md.rs
+++ b/src/md.rs
@@ -485,7 +485,7 @@ pub(crate) fn mess_ratio(
 
     let length = decoded_sequence.chars().count();
     let mut mean_mess_ratio: f32 = 0.0;
-    let intermediary_mean_mess_ratio_calc: u64 = match length {
+    let intermediary_mean_mess_ratio_calc: usize = match length {
         0..=511 => 32,
         512..=1024 => 64,
         _ => 128,
@@ -500,8 +500,8 @@ pub(crate) fn mess_ratio(
             }
         }
 
-        if (index > 0 && index as u64 % intermediary_mean_mess_ratio_calc == 0)
-            || index == (length)
+        if (index > 0 && index.rem_euclid(intermediary_mean_mess_ratio_calc) == 0)
+            || index == length
         {
             mean_mess_ratio = detectors.iter().map(|x| x.ratio()).sum();
             if mean_mess_ratio >= maximum_threshold {

--- a/src/md.rs
+++ b/src/md.rs
@@ -483,7 +483,7 @@ pub(crate) fn mess_ratio(
         Box::<ArchaicUpperLowerPlugin>::default(),
     ];
 
-    let length = decoded_sequence.chars().count() + 1;
+    let length = decoded_sequence.chars().count();
     let mut mean_mess_ratio: f32 = 0.0;
     let intermediary_mean_mess_ratio_calc: u64 = match length {
         0..=511 => 32,
@@ -501,7 +501,7 @@ pub(crate) fn mess_ratio(
         }
 
         if (index > 0 && index as u64 % intermediary_mean_mess_ratio_calc == 0)
-            || index == (length - 1)
+            || index == (length)
         {
             mean_mess_ratio = detectors.iter().map(|x| x.ratio()).sum();
             if mean_mess_ratio >= maximum_threshold {

--- a/src/md.rs
+++ b/src/md.rs
@@ -486,8 +486,8 @@ pub(crate) fn mess_ratio(
     let length = decoded_sequence.chars().count();
     let mut mean_mess_ratio: f32 = 0.0;
     let intermediary_mean_mess_ratio_calc: usize = match length {
-        0..=511 => 32,
-        512..=1024 => 64,
+        0..=510 => 32,
+        511..=1023 => 64,
         _ => 128,
     };
     let new_sequence = decoded_sequence.to_string() + "\n";

--- a/src/md.rs
+++ b/src/md.rs
@@ -490,10 +490,12 @@ pub(crate) fn mess_ratio(
         511..=1023 => 64,
         _ => 128,
     };
-    let new_sequence = decoded_sequence.to_string() + "\n";
-
     // Traverse through chars and detectors
-    for (index, ch) in new_sequence.chars().enumerate() {
+    for (index, ch) in decoded_sequence
+        .chars()
+        .chain(std::iter::once('\n'))
+        .enumerate()
+    {
         for detector in &mut *detectors {
             if detector.eligible(&ch) {
                 detector.feed(&ch);

--- a/src/normalizer.rs
+++ b/src/normalizer.rs
@@ -11,12 +11,8 @@ use std::{fs, process};
 
 fn write_str_to_file(filename: &PathBuf, content: &str) -> std::io::Result<()> {
     // Open the file for writing, creating it if it doesn't exist.
-    let mut file = File::create(filename)?;
+    File::create(filename)?.write_all(content.as_bytes())
 
-    // Write the content to the file.
-    file.write_all(content.as_bytes())?;
-
-    Ok(())
 }
 
 fn normalizer(args: &CLINormalizerArgs) -> Result<i32, String> {

--- a/src/normalizer.rs
+++ b/src/normalizer.rs
@@ -176,13 +176,8 @@ pub fn main() {
     }
 
     // run normalizer
-    let exit_code = match normalizer(&args) {
-        Err(e) => {
-            eprintln!("{}", e);
-            1
-        }
-        Ok(code) => code,
-    };
-
-    process::exit(exit_code);
+    match normalizer(&args) {
+        Err(e) => panic!("{e}"),
+        Ok(exit_code) => process::exit(exit_code),
+    }
 }

--- a/src/normalizer.rs
+++ b/src/normalizer.rs
@@ -154,12 +154,12 @@ fn normalizer(args: &CLINormalizerArgs) -> Result<i32, String> {
     // print out results
     if args.minimal {
         for path in &args.files {
-            let full_path = &fs::canonicalize(path).unwrap();
+            let full_path = fs::canonicalize(path).unwrap();
             println!(
                 "{}",
                 results
                     .iter()
-                    .filter(|&r| &r.path == full_path)
+                    .filter(|r| r.path == full_path)
                     .map(|r| r.encoding.clone().unwrap_or("undefined".to_string()))
                     .collect::<Vec<_>>()
                     .join(", ")

--- a/src/normalizer.rs
+++ b/src/normalizer.rs
@@ -188,12 +188,7 @@ pub fn main() {
 
     // run normalizer
     match normalizer(&args) {
-        Err(e) => {
-            eprintln!("{}", e);
-            process::exit(1);
-        }
-        Ok(exit_code) => {
-            process::exit(exit_code);
-        }
+        Err(e) => panic!("{e}"),
+        Ok(exit_code) => process::exit(exit_code)
     }
 }

--- a/src/normalizer.rs
+++ b/src/normalizer.rs
@@ -6,14 +6,7 @@ use env_logger::Env;
 use ordered_float::OrderedFloat;
 use std::fs::File;
 use std::io::Write;
-use std::path::PathBuf;
 use std::{fs, process};
-
-fn write_str_to_file(filename: &PathBuf, content: &str) -> std::io::Result<()> {
-    // Open the file for writing, creating it if it doesn't exist.
-    File::create(filename)?.write_all(content.as_bytes())
-
-}
 
 fn normalizer(args: &CLINormalizerArgs) -> Result<i32, String> {
     if args.replace && !args.normalize {
@@ -137,9 +130,9 @@ fn normalizer(args: &CLINormalizerArgs) -> Result<i32, String> {
                     results[0].unicode_path = Some(full_path.clone());
 
                     // replace file contents
-                    if let Err(err) =
-                        write_str_to_file(full_path, best_guess.decoded_payload().unwrap())
-                    {
+                    if let Err(err) = File::create(full_path).and_then(|mut file| {
+                        file.write_all(best_guess.decoded_payload().unwrap().as_bytes())
+                    }) {
                         return Err(err.to_string());
                     }
                 }
@@ -185,6 +178,6 @@ pub fn main() {
     // run normalizer
     match normalizer(&args) {
         Err(e) => panic!("{e}"),
-        Ok(exit_code) => process::exit(exit_code)
+        Ok(exit_code) => process::exit(exit_code),
     }
 }

--- a/src/normalizer.rs
+++ b/src/normalizer.rs
@@ -176,8 +176,13 @@ pub fn main() {
     }
 
     // run normalizer
-    match normalizer(&args) {
-        Err(e) => panic!("{e}"),
-        Ok(exit_code) => process::exit(exit_code),
-    }
+    let exit_code = match normalizer(&args) {
+        Err(e) => {
+            eprintln!("{}", e);
+            1
+        }
+        Ok(code) => code,
+    };
+
+    process::exit(exit_code);
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -28,8 +28,8 @@ fn in_category(
     ranges_partial: &[&str],
 ) -> bool {
     // unicode category part
-    let category = GeneralCategory::of(*character).abbr_name().to_string();
-    if categories_exact.contains(&&*category)
+    let category = GeneralCategory::of(*character).abbr_name();
+    if categories_exact.contains(&category)
         || categories_partial.iter().any(|&cp| category.contains(cp))
     {
         return true;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -45,11 +45,13 @@ fn in_category(
 
 // check if character description contains at least one of patterns
 fn in_description(character: &char, patterns: &[&str]) -> bool {
-    if let Some(description) = Name::of(*character) {
-        let description = format!("{}", description);
-        return patterns.iter().any(|&s| description.contains(s));
-    }
-    false
+    Name::of(*character)
+        .map(|description| {
+            patterns
+                .iter()
+                .any(|&s| description.to_string().contains(s))
+        })
+        .unwrap_or(false)
 }
 
 #[cache(LruCache: LruCache::new(*UTF8_MAXIMAL_ALLOCATION))]


### PR DESCRIPTION
c918f37 and 0b3ff3b need special attention.

Since the length + 1 was not necessary, i removed it and changed some code (length - 1) downstream.

This does affect the match range, and so i changed the range to match the original behavior, but it looks strange now 
(0~510 instead of 512?)

other than that it is mostly sideeffectless changes, except 7d65129 which changed exit behavior.

If the original exit code 1 is strictly necessary there are other ways to do recover the behavior as well.