### PR TITLE
Entity 

### DIFF
--- a/src/cd.rs
+++ b/src/cd.rs
@@ -52,9 +52,6 @@ pub(crate) fn encoding_unicode_range(iana_name: &str) -> Result<Vec<&str>, Strin
 
 // Return inferred languages used with a unicode range.
 pub(crate) fn unicode_range_languages(primary_range: &str) -> Vec<&'static Language> {
-    if primary_range.is_empty() {
-        return vec![];
-    }
     LANGUAGES
         .iter()
         .filter_map(|(language, characters, _, _)| {
@@ -63,7 +60,7 @@ pub(crate) fn unicode_range_languages(primary_range: &str) -> Vec<&'static Langu
                 .find(|&character| unicode_range(&character).unwrap_or_default() == primary_range)
                 .map(|_| language)
         })
-        .collect()
+        .collect::<Vec<&Language>>()
 }
 
 // Single-byte encoding language association.

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -225,17 +225,11 @@ impl CharsetMatch {
                 if self.suitable_encodings().contains(&String::from("ascii")) {
                     return &Language::English;
                 }
-
                 let languages = if is_multi_byte_encoding(&self.encoding) {
                     mb_encoding_languages(&self.encoding)
                 } else {
                     encoding_languages(self.encoding.clone())
                 };
-
-                if languages.contains(&&Language::Unknown) {
-                    return &Language::Unknown;
-                }
-
                 languages.first().unwrap_or(&&Language::Unknown)
             })
     }

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -198,10 +198,10 @@ impl CharsetMatch {
 
     // Get encoding aliases according to https://encoding.spec.whatwg.org/encodings.json
     pub fn encoding_aliases(&self) -> Vec<&'static str> {
-        if let Some(res) = IANA_SUPPORTED_ALIASES.get(&self.encoding.as_str()) {
-            return res.clone();
-        }
-        vec![]
+        IANA_SUPPORTED_ALIASES
+            .get(&self.encoding.as_str())
+            .cloned()
+            .unwrap_or_default()
     }
     // byte_order_mark
     pub fn bom(&self) -> bool {

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -232,11 +232,11 @@ impl CharsetMatch {
                     encoding_languages(self.encoding.clone())
                 };
 
-                if languages.is_empty() || languages.contains(&&Language::Unknown) {
+                if languages.contains(&&Language::Unknown) {
                     return &Language::Unknown;
                 }
 
-                languages.first().unwrap()
+                languages.first().unwrap_or(&&Language::Unknown)
             })
     }
     // Return the complete list of possible languages found in decoded sequence.

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -160,28 +160,22 @@ impl CharsetMatch {
         };
 
         // decoded payload recalc
-        if obj.decoded_payload.is_none() {
-            if let Ok(res) = decode(
-                &obj.payload,
-                obj.encoding.as_str(),
-                DecoderTrap::Strict,
-                false,
-                true,
-            ) {
-                obj.decoded_payload =
-                    Some(res.strip_prefix('\u{feff}').unwrap_or(&res).to_string());
+        match &obj.decoded_payload {
+            None => {
+                if let Ok(res) = decode(
+                    &obj.payload,
+                    obj.encoding.as_str(),
+                    DecoderTrap::Strict,
+                    false,
+                    true,
+                ) {
+                    obj.decoded_payload =
+                        Some(res.strip_prefix('\u{feff}').unwrap_or(&res).to_string());
+                }
             }
-        }
-        if obj.decoded_payload.is_some() {
-            obj.fingerprint = format!(
-                "{:?}",
-                blake3::hash(
-                    obj.decoded_payload
-                        .as_ref()
-                        .unwrap_or(&String::default())
-                        .as_bytes()
-                )
-            );
+            Some(payload) => {
+                obj.fingerprint = format!("{:?}", blake3::hash(payload.as_bytes().clone()));
+            }
         }
         obj
     }


### PR DESCRIPTION
592c2d3 needs some careful introspection.

I wrote down my reasoning for the code.
I read multiple pathways that lead up to that point, and it doesn't seem like a case where there are multiple encodings included with an `unknown` so suppressing this case and allowing for `unwrap_or` would be better.

If I am wrong it would mean giving precedence to a non unknown encoding over a default unknown return value. This might change behavior but not necessarily in a wrong way.

That being said the tests for that fn do not seem to cover this kind of case (multiple values including an `unknown`)