### PR TITLE
Using alternative hash function for HashMaps, HashSets & LRU caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
  "cfg-if",
+ "getrandom",
  "once_cell",
  "version_check",
 ]
@@ -77,18 +78,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayref"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
-
-[[package]]
 name = "assert_cmd"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,29 +122,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
-name = "blake3"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "199c42ab6972d92c9f8995f086273d25c42fc0f7b2a1fcefba465c1352d25ba5"
-dependencies = [
- "arrayref",
- "arrayvec",
- "cc",
- "cfg-if",
- "constant_time_eq",
- "digest",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "bstr"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,18 +137,6 @@ name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
-
-[[package]]
-name = "cache-macro-stable-rust"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b66d245a5f4655e4c698a317045b2bed82275f6f42c1682ffcbd096827adc"
-dependencies = [
- "lazy_static",
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
-]
 
 [[package]]
 name = "cached"
@@ -206,8 +160,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8245dd5f576a41c3b76247b54c15b0e43139ceeb4f732033e15be7c005176"
 dependencies = [
  "darling",
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -259,9 +213,8 @@ dependencies = [
 name = "charset-normalizer-rs"
 version = "1.0.5"
 dependencies = [
+ "ahash",
  "assert_cmd",
- "blake3",
- "cache-macro-stable-rust",
  "cached",
  "chardet",
  "chardetng",
@@ -273,8 +226,6 @@ dependencies = [
  "env_logger",
  "lazy_static",
  "log",
- "lru-cache",
- "maplit",
  "ordered-float",
  "predicates",
  "regex",
@@ -324,8 +275,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
 dependencies = [
  "heck",
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.31",
 ]
 
@@ -353,12 +304,6 @@ dependencies = [
  "unicode-width",
  "windows-sys 0.45.0",
 ]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "counter"
@@ -449,16 +394,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
 name = "csv"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,8 +432,8 @@ checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "strsim",
  "syn 1.0.109",
 ]
@@ -510,7 +445,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
  "darling_core",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -531,17 +466,6 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
- "subtle",
-]
 
 [[package]]
 name = "doc-comment"
@@ -690,13 +614,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
+name = "getrandom"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
- "typenum",
- "version_check",
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -805,12 +730,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -821,21 +740,6 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
-
-[[package]]
-name = "lru-cache"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
-dependencies = [
- "linked-hash-map",
-]
-
-[[package]]
-name = "maplit"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matches"
@@ -965,15 +869,6 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid",
-]
-
-[[package]]
-name = "proc-macro2"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
@@ -983,20 +878,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
-]
-
-[[package]]
-name = "quote"
 version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -1118,8 +1004,8 @@ version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.31",
 ]
 
@@ -1147,30 +1033,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
-name = "subtle"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
-
-[[package]]
-name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid",
-]
-
-[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -1180,8 +1049,8 @@ version = "2.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "718fa2415bcb8d8bd775917a1bf12a7931b6dfa890753378538118181e0cb398"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -1237,8 +1106,8 @@ version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.31",
 ]
 
@@ -1251,12 +1120,6 @@ dependencies = [
  "serde",
  "serde_json",
 ]
-
-[[package]]
-name = "typenum"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unic"
@@ -1567,12 +1430,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
-name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-
-[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1604,6 +1461,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1622,8 +1485,8 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.31",
  "wasm-bindgen-shared",
 ]
@@ -1634,7 +1497,7 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
- "quote 1.0.33",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
@@ -1644,8 +1507,8 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.31",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +21,12 @@ checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "anstream"
@@ -168,6 +185,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "cached"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cead8ece0da6b744b2ad8ef9c58a4cdc7ef2921e60a6ddfb9eaaa86839b5fc5"
+dependencies = [
+ "ahash",
+ "cached_proc_macro",
+ "cached_proc_macro_types",
+ "hashbrown",
+ "instant",
+ "once_cell",
+ "thiserror",
+]
+
+[[package]]
+name = "cached_proc_macro"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8245dd5f576a41c3b76247b54c15b0e43139ceeb4f732033e15be7c005176"
+dependencies = [
+ "darling",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "cached_proc_macro_types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a4f925191b4367301851c6d99b09890311d74b0d43f274c0b34c86d308a3663"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,6 +262,7 @@ dependencies = [
  "assert_cmd",
  "blake3",
  "cache-macro-stable-rust",
+ "cached",
  "chardet",
  "chardetng",
  "clap 4.4.2",
@@ -429,6 +480,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "strsim",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,6 +684,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,6 +704,16 @@ name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -639,6 +741,21 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "is-terminal"
@@ -1048,6 +1165,17 @@ dependencies = [
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "718fa2415bcb8d8bd775917a1bf12a7931b6dfa890753378538118181e0cb398"
@@ -1092,6 +1220,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
+dependencies = [
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "syn 2.0.31",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,7 @@ exclude = [
 ]
 
 [dependencies]
-blake3 = "1.4.1"
-cache-macro-stable-rust = "0.4.1"
+ahash = "0.8.3"
 cached = "0.46.0"
 chardet = { version = "0.2.4", optional = true }
 chardetng = { version = "0.1.17", optional = true }
@@ -31,8 +30,6 @@ encoding = "0.2.33"
 env_logger = "0.10.0"
 lazy_static = "1.4.0"
 log = "0.4.20"
-lru-cache = "0.1.2"
-maplit = "1.0.2"
 ordered-float = "3.9.1"
 regex = "1.9.3"
 serde = { version = "1.0.188", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ exclude = [
 [dependencies]
 blake3 = "1.4.1"
 cache-macro-stable-rust = "0.4.1"
+cached = "0.46.0"
 chardet = { version = "0.2.4", optional = true }
 chardetng = { version = "0.1.17", optional = true }
 clap = { version = "4.4.2", features = ["derive"] }

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -1,7 +1,6 @@
 use crate::entity::Language;
+use ahash::HashMap;
 use lazy_static::lazy_static;
-use maplit::hashmap;
-use std::collections::HashMap;
 
 lazy_static! {
     pub static ref LANGUAGES: Vec<(Language, &'static str, bool, bool)> = vec![
@@ -52,14 +51,14 @@ lazy_static! {
    pub static ref LANGUAGE_SUPPORTED_COUNT: usize = LANGUAGES.len();
 
    // direct binding encoding to language
-   pub(crate) static ref ENCODING_TO_LANGUAGE: HashMap<&'static str, Language> = hashmap!{
-     "euc-kr" => Language::Korean,
-     "big5" => Language::Chinese,
-     "hz" => Language::Chinese,
-     "gbk" => Language::Chinese,
-     "gb18030" => Language::Chinese,
-     "euc-jp" => Language::Japanese,
-     "iso-2022-jp" => Language::Japanese,
-     "shift_jis" =>  Language::Japanese,
-   };
+   pub(crate) static ref ENCODING_TO_LANGUAGE: HashMap<&'static str, Language> = HashMap::from_iter([
+     ("euc-kr", Language::Korean),
+     ("big5", Language::Chinese),
+     ("hz", Language::Chinese),
+     ("gbk", Language::Chinese),
+     ("gb18030", Language::Chinese),
+     ("euc-jp", Language::Japanese),
+     ("iso-2022-jp", Language::Japanese),
+     ("shift_jis",  Language::Japanese),
+   ]);
 }

--- a/src/cd.rs
+++ b/src/cd.rs
@@ -39,6 +39,7 @@ pub(crate) fn encoding_unicode_range(iana_name: &str) -> Result<Vec<&str>, Strin
             }
         }
     }
+
     let threshold = 0.15;
     let mut result: Vec<&str> = result
         .iter()

--- a/src/cd.rs
+++ b/src/cd.rs
@@ -11,6 +11,7 @@ use lru_cache::LruCache;
 use ordered_float::OrderedFloat;
 use std::collections::{HashMap, HashSet};
 use strsim::jaro;
+use cached::proc_macro::cached;
 
 //
 // Coherence detection module
@@ -66,6 +67,7 @@ pub(crate) fn unicode_range_languages(primary_range: &str) -> Vec<&'static Langu
 // Single-byte encoding language association.
 // Some code page are heavily linked to particular language(s).
 // This function does the correspondence.
+//#[cached]
 #[cache(LruCache : LruCache::new(128))]
 pub(crate) fn encoding_languages(iana_name: String) -> Vec<&'static Language> {
     match encoding_unicode_range(&iana_name)
@@ -201,6 +203,7 @@ pub(crate) fn merge_coherence_ratios(results: &Vec<CoherenceMatches>) -> Coheren
 // The main function. Detect ANY language that can be identified in given sequence.
 // The sequence will be analysed by layers.
 // A layer = Character extraction by alphabets/ranges.
+//#[cached]
 #[cache(LruCache: LruCache::new(2048))]
 pub(crate) fn coherence_ratio(
     decoded_sequence: String,

--- a/src/cd.rs
+++ b/src/cd.rs
@@ -3,15 +3,13 @@ use crate::assets::*;
 use crate::consts::TOO_SMALL_SEQUENCE;
 use crate::entity::*;
 use crate::utils::*;
-use cache_macro_stable_rust::cache;
+use ahash::{HashMap, HashMapExt, HashSet};
+use cached::proc_macro::cached;
 use counter::Counter;
 use encoding::label::encoding_from_whatwg_label;
 use encoding::DecoderTrap;
-use lru_cache::LruCache;
 use ordered_float::OrderedFloat;
-use std::collections::{HashMap, HashSet};
 use strsim::jaro;
-use cached::proc_macro::cached;
 
 //
 // Coherence detection module
@@ -67,8 +65,7 @@ pub(crate) fn unicode_range_languages(primary_range: &str) -> Vec<&'static Langu
 // Single-byte encoding language association.
 // Some code page are heavily linked to particular language(s).
 // This function does the correspondence.
-//#[cached]
-#[cache(LruCache : LruCache::new(128))]
+#[cached(size = 128)]
 pub(crate) fn encoding_languages(iana_name: String) -> Vec<&'static Language> {
     match encoding_unicode_range(&iana_name)
         .unwrap_or_default()
@@ -203,8 +200,7 @@ pub(crate) fn merge_coherence_ratios(results: &Vec<CoherenceMatches>) -> Coheren
 // The main function. Detect ANY language that can be identified in given sequence.
 // The sequence will be analysed by layers.
 // A layer = Character extraction by alphabets/ranges.
-//#[cached]
-#[cache(LruCache: LruCache::new(2048))]
+#[cached(size = 2048)]
 pub(crate) fn coherence_ratio(
     decoded_sequence: String,
     threshold: Option<OrderedFloat<f32>>,

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,20 +1,18 @@
+use ahash::{HashMap, HashSet};
 use encoding::all::encodings;
 use lazy_static::lazy_static;
-use maplit::{hashmap, hashset};
 use regex::Regex;
-use std::collections::HashMap;
-use std::collections::HashSet;
 use std::ops::Range;
 
 lazy_static! {
 
     // Contain for each eligible encoding a list of/item bytes SIG/BOM
-    pub(crate) static ref ENCODING_MARKS: HashMap<&'static str, &'static [u8]> = hashmap!{
-        "utf-8" => b"\xef\xbb\xbf".as_slice(),
-        "gb18030" => b"\x84\x31\x95\x33".as_slice(),
-        "utf-16le" => b"\xff\xfe".as_slice(),
-        "utf-16be" => b"\xfe\xff".as_slice(),
-    };
+    pub(crate) static ref ENCODING_MARKS: HashMap<&'static str, &'static [u8]> = HashMap::from_iter([
+        ("utf-8", b"\xef\xbb\xbf".as_slice()),
+        ("gb18030", b"\x84\x31\x95\x33".as_slice()),
+        ("utf-16le", b"\xff\xfe".as_slice()),
+        ("utf-16be", b"\xfe\xff".as_slice()),
+    ]);
 
     pub static ref MAX_PROCESSED_BYTES: usize = 500_000;
     pub static ref TOO_SMALL_SEQUENCE: usize = 32;
@@ -303,8 +301,7 @@ lazy_static! {
         ("Variation Selectors Supplement", 917760..917999 + 1),
     ];
 
-    pub(crate) static ref UNICODE_SECONDARY_RANGE_KEYWORD: HashSet<&'static str> = hashset!(
-        "Supplement",
+    pub(crate) static ref UNICODE_SECONDARY_RANGE_KEYWORD: HashSet<&'static str> = HashSet::from_iter([
         "Extended",
         "Extensions",
         "Modifier",
@@ -319,7 +316,7 @@ lazy_static! {
         "Shapes",
         "Supplemental",
         "Tags",
-    );
+    ]);
 
     pub(crate) static ref COMMON_SAFE_ASCII_CHARACTERS: &'static str = "<>=:/&;{}[],|\"-";
 
@@ -336,110 +333,110 @@ lazy_static! {
     pub static ref IANA_SUPPORTED_COUNT: usize = IANA_SUPPORTED.len();
 
     // chardet encoding names (in lowercase!)
-    pub static ref CHARDET_CORRESPONDENCE: HashMap<&'static str, &'static str> = hashmap!{
-        "tis-620" => "windows-874",
-        "utf-16" => "utf-16le",
-        "maccyrillic" => "x-mac-cyrillic",
-        "gb2312" => "gbk",
-        "cp949" => "euc-kr",
-    };
+    pub static ref CHARDET_CORRESPONDENCE: HashMap<&'static str, &'static str> = HashMap::from_iter([
+        ("tis-620", "windows-874"),
+        ("utf-16", "utf-16le"),
+        ("maccyrillic", "x-mac-cyrillic"),
+        ("gb2312", "gbk"),
+        ("cp949", "euc-kr"),
+    ]);
 
     // aliases (labels) are from https://encoding.spec.whatwg.org/#concept-encoding-get -> as is + lowercased
-    pub static ref IANA_SUPPORTED_ALIASES: HashMap<&'static str, Vec<&'static str>> = hashmap!{
-        "utf-8" => vec!["unicode-1-1-utf-8", "unicode11utf8", "unicode20utf8", "utf-8", "utf8", "x-unicode20utf8"],
-        "ibm866" => vec!["866", "cp866", "csibm866", "ibm866"],
-        "iso-8859-2" => vec!["csisolatin2", "iso-8859-2", "iso-ir-101", "iso8859-2", "iso88592", "iso_8859-2", "iso_8859-2:1987", "l2", "latin2"],
-        "iso-8859-3" => vec!["csisolatin3", "iso-8859-3", "iso-ir-109", "iso8859-3", "iso88593", "iso_8859-3", "iso_8859-3:1988", "l3", "latin3"],
-        "iso-8859-4" => vec!["csisolatin4", "iso-8859-4", "iso-ir-110", "iso8859-4", "iso88594", "iso_8859-4", "iso_8859-4:1988", "l4", "latin4"],
-        "iso-8859-5" => vec!["csisolatincyrillic", "cyrillic", "iso-8859-5", "iso-ir-144", "iso8859-5", "iso88595", "iso_8859-5", "iso_8859-5:1988"],
-        "iso-8859-6" => vec!["arabic", "asmo-708", "csiso88596e", "csiso88596i", "csisolatinarabic", "ecma-114", "iso-8859-6", "iso-8859-6-e", "iso-8859-6-i", "iso-ir-127", "iso8859-6", "iso88596", "iso_8859-6", "iso_8859-6:1987"],
-        "iso-8859-7" => vec!["csisolatingreek", "ecma-118", "elot_928", "greek", "greek8", "iso-8859-7", "iso-ir-126", "iso8859-7", "iso88597", "iso_8859-7", "iso_8859-7:1987", "sun_eu_greek"],
-        "iso-8859-8" => vec!["csiso88598e", "csisolatinhebrew", "hebrew", "iso-8859-8", "iso-8859-8-e", "iso-ir-138", "iso8859-8", "iso88598", "iso_8859-8", "iso_8859-8:1988", "visual"],
-        "iso-8859-8-i" => vec!["csiso88598i", "iso-8859-8-i", "logical"],
-        "iso-8859-10" => vec!["csisolatin6", "iso-8859-10", "iso-ir-157", "iso8859-10", "iso885910", "l6", "latin6"],
-        "iso-8859-13" => vec!["iso-8859-13", "iso8859-13", "iso885913"],
-        "iso-8859-14" => vec!["iso-8859-14", "iso8859-14", "iso885914"],
-        "iso-8859-15" => vec!["csisolatin9", "iso-8859-15", "iso8859-15", "iso885915", "iso_8859-15", "l9"],
-        "iso-8859-16" => vec!["iso-8859-16"],
-        "koi8-r" => vec!["cskoi8r", "koi", "koi8", "koi8-r", "koi8_r"],
-        "koi8-u" => vec!["koi8-ru", "koi8-u"],
-        "macintosh" => vec!["csmacintosh", "mac", "macintosh", "x-mac-roman"],
-        "windows-874" => vec!["dos-874", "iso-8859-11", "iso8859-11", "iso885911", "tis-620", "windows-874"],
-        "windows-1250" => vec!["cp1250", "windows-1250", "x-cp1250"],
-        "windows-1251" => vec!["cp1251", "windows-1251", "x-cp1251"],
-        "windows-1252" => vec!["ansi_x3.4-1968", "ascii", "cp1252", "cp819", "csisolatin1", "ibm819", "iso-8859-1", "iso-ir-100", "iso8859-1", "iso88591", "iso_8859-1", "iso_8859-1:1987", "l1", "latin1", "us-ascii", "windows-1252", "x-cp1252"],
-        "windows-1253" => vec!["cp1253", "windows-1253", "x-cp1253"],
-        "windows-1254" => vec!["cp1254", "csisolatin5", "iso-8859-9", "iso-ir-148", "iso8859-9", "iso88599", "iso_8859-9", "iso_8859-9:1989", "l5", "latin5", "windows-1254", "x-cp1254"],
-        "windows-1255" => vec!["cp1255", "windows-1255", "x-cp1255"],
-        "windows-1256" => vec!["cp1256", "windows-1256", "x-cp1256"],
-        "windows-1257" => vec!["cp1257", "windows-1257", "x-cp1257"],
-        "windows-1258" => vec!["cp1258", "windows-1258", "x-cp1258"],
-        "x-mac-cyrillic" => vec!["x-mac-cyrillic", "x-mac-ukrainian"],
-        "gbk" => vec!["chinese", "csgb2312", "csiso58gb231280", "gb2312", "gb_2312", "gb_2312-80", "gbk", "iso-ir-58", "x-gbk"],
-        "gb18030" => vec!["gb18030"],
-        "big5" => vec!["big5", "big5-hkscs", "cn-big5", "csbig5", "x-x-big5"],
-        "euc-jp" => vec!["cseucpkdfmtjapanese", "euc-jp", "x-euc-jp"],
-        "iso-2022-jp" => vec!["csiso2022jp", "iso-2022-jp"],
-        "shift_jis" => vec!["csshiftjis", "ms932", "ms_kanji", "shift-jis", "shift_jis", "sjis", "windows-31j", "x-sjis"],
-        "euc-kr" => vec!["cseuckr", "csksc56011987", "euc-kr", "iso-ir-149", "korean", "ks_c_5601-1987", "ks_c_5601-1989", "ksc5601", "ksc_5601", "windows-949"],
-        "replacement" => vec!["csiso2022kr", "hz-gb-2312", "iso-2022-cn", "iso-2022-cn-ext", "iso-2022-kr", "replacement"],
-        "utf-16be" => vec!["unicodefffe", "utf-16be"],
-        "utf-16le" => vec!["csunicode", "iso-10646-ucs-2", "ucs-2", "unicode", "unicodefeff", "utf-16", "utf-16le"],
-        "x-user-defined" => vec!["x-user-defined"],
-    };
+    pub static ref IANA_SUPPORTED_ALIASES: HashMap<&'static str, Vec<&'static str>> = HashMap::from_iter([
+        ("utf-8", vec!["unicode-1-1-utf-8", "unicode11utf8", "unicode20utf8", "utf-8", "utf8", "x-unicode20utf8"]),
+        ("ibm866", vec!["866", "cp866", "csibm866", "ibm866"]),
+        ("iso-8859-2", vec!["csisolatin2", "iso-8859-2", "iso-ir-101", "iso8859-2", "iso88592", "iso_8859-2", "iso_8859-2:1987", "l2", "latin2"]),
+        ("iso-8859-3", vec!["csisolatin3", "iso-8859-3", "iso-ir-109", "iso8859-3", "iso88593", "iso_8859-3", "iso_8859-3:1988", "l3", "latin3"]),
+        ("iso-8859-4", vec!["csisolatin4", "iso-8859-4", "iso-ir-110", "iso8859-4", "iso88594", "iso_8859-4", "iso_8859-4:1988", "l4", "latin4"]),
+        ("iso-8859-5", vec!["csisolatincyrillic", "cyrillic", "iso-8859-5", "iso-ir-144", "iso8859-5", "iso88595", "iso_8859-5", "iso_8859-5:1988"]),
+        ("iso-8859-6", vec!["arabic", "asmo-708", "csiso88596e", "csiso88596i", "csisolatinarabic", "ecma-114", "iso-8859-6", "iso-8859-6-e", "iso-8859-6-i", "iso-ir-127", "iso8859-6", "iso88596", "iso_8859-6", "iso_8859-6:1987"]),
+        ("iso-8859-7", vec!["csisolatingreek", "ecma-118", "elot_928", "greek", "greek8", "iso-8859-7", "iso-ir-126", "iso8859-7", "iso88597", "iso_8859-7", "iso_8859-7:1987", "sun_eu_greek"]),
+        ("iso-8859-8", vec!["csiso88598e", "csisolatinhebrew", "hebrew", "iso-8859-8", "iso-8859-8-e", "iso-ir-138", "iso8859-8", "iso88598", "iso_8859-8", "iso_8859-8:1988", "visual"]),
+        ("iso-8859-8-i", vec!["csiso88598i", "iso-8859-8-i", "logical"]),
+        ("iso-8859-10", vec!["csisolatin6", "iso-8859-10", "iso-ir-157", "iso8859-10", "iso885910", "l6", "latin6"]),
+        ("iso-8859-13", vec!["iso-8859-13", "iso8859-13", "iso885913"]),
+        ("iso-8859-14", vec!["iso-8859-14", "iso8859-14", "iso885914"]),
+        ("iso-8859-15", vec!["csisolatin9", "iso-8859-15", "iso8859-15", "iso885915", "iso_8859-15", "l9"]),
+        ("iso-8859-16", vec!["iso-8859-16"]),
+        ("koi8-r", vec!["cskoi8r", "koi", "koi8", "koi8-r", "koi8_r"]),
+        ("koi8-u", vec!["koi8-ru", "koi8-u"]),
+        ("macintosh", vec!["csmacintosh", "mac", "macintosh", "x-mac-roman"]),
+        ("windows-874", vec!["dos-874", "iso-8859-11", "iso8859-11", "iso885911", "tis-620", "windows-874"]),
+        ("windows-1250", vec!["cp1250", "windows-1250", "x-cp1250"]),
+        ("windows-1251", vec!["cp1251", "windows-1251", "x-cp1251"]),
+        ("windows-1252", vec!["ansi_x3.4-1968", "ascii", "cp1252", "cp819", "csisolatin1", "ibm819", "iso-8859-1", "iso-ir-100", "iso8859-1", "iso88591", "iso_8859-1", "iso_8859-1:1987", "l1", "latin1", "us-ascii", "windows-1252", "x-cp1252"]),
+        ("windows-1253", vec!["cp1253", "windows-1253", "x-cp1253"]),
+        ("windows-1254", vec!["cp1254", "csisolatin5", "iso-8859-9", "iso-ir-148", "iso8859-9", "iso88599", "iso_8859-9", "iso_8859-9:1989", "l5", "latin5", "windows-1254", "x-cp1254"]),
+        ("windows-1255", vec!["cp1255", "windows-1255", "x-cp1255"]),
+        ("windows-1256", vec!["cp1256", "windows-1256", "x-cp1256"]),
+        ("windows-1257", vec!["cp1257", "windows-1257", "x-cp1257"]),
+        ("windows-1258", vec!["cp1258", "windows-1258", "x-cp1258"]),
+        ("x-mac-cyrillic", vec!["x-mac-cyrillic", "x-mac-ukrainian"]),
+        ("gbk", vec!["chinese", "csgb2312", "csiso58gb231280", "gb2312", "gb_2312", "gb_2312-80", "gbk", "iso-ir-58", "x-gbk"]),
+        ("gb18030", vec!["gb18030"]),
+        ("big5", vec!["big5", "big5-hkscs", "cn-big5", "csbig5", "x-x-big5"]),
+        ("euc-jp", vec!["cseucpkdfmtjapanese", "euc-jp", "x-euc-jp"]),
+        ("iso-2022-jp", vec!["csiso2022jp", "iso-2022-jp"]),
+        ("shift_jis", vec!["csshiftjis", "ms932", "ms_kanji", "shift-jis", "shift_jis", "sjis", "windows-31j", "x-sjis"]),
+        ("euc-kr", vec!["cseuckr", "csksc56011987", "euc-kr", "iso-ir-149", "korean", "ks_c_5601-1987", "ks_c_5601-1989", "ksc5601", "ksc_5601", "windows-949"]),
+        ("replacement", vec!["csiso2022kr", "hz-gb-2312", "iso-2022-cn", "iso-2022-cn-ext", "iso-2022-kr", "replacement"]),
+        ("utf-16be", vec!["unicodefffe", "utf-16be"]),
+        ("utf-16le", vec!["csunicode", "iso-10646-ucs-2", "ucs-2", "unicode", "unicodefeff", "utf-16", "utf-16le"]),
+        ("x-user-defined", vec!["x-user-defined"]),
+    ]);
 
-    pub static ref IANA_SUPPORTED_SIMILAR: HashMap<&'static str, Vec<&'static str>> = hashmap!{
-        "windows-1252" => vec!["iso-8859-15", "windows-1254"],
-        "windows-1253" => vec!["iso-8859-7"],
-        "windows-1254" => vec!["iso-8859-15", "windows-1252"],
-        "windows-1257" => vec!["iso-8859-13"],
-        "iso-8859-10" => vec!["iso-8859-14", "iso-8859-15", "iso-8859-4", "windows-1254", "windows-1252"],
-        "iso-8859-13" => vec!["windows-1257"],
-        "iso-8859-14" => vec![
+    pub static ref IANA_SUPPORTED_SIMILAR: HashMap<&'static str, Vec<&'static str>> = HashMap::from_iter([
+        ("windows-1252", vec!["iso-8859-15", "windows-1254"]),
+        ("windows-1253", vec!["iso-8859-7"]),
+        ("windows-1254", vec!["iso-8859-15", "windows-1252"]),
+        ("windows-1257", vec!["iso-8859-13"]),
+        ("iso-8859-10", vec!["iso-8859-14", "iso-8859-15", "iso-8859-4", "windows-1254", "windows-1252"]),
+        ("iso-8859-13", vec!["windows-1257"]),
+        ("iso-8859-14", vec![
             "iso-8859-10",
             "iso-8859-15",
             "iso-8859-16",
             "iso-8859-3",
             "windows-1254",
             "windows-1252",
-        ],
-        "iso-8859-15" => vec![
+        ]),
+        ("iso-8859-15", vec![
             "windows-1252",
             "windows-1254",
             "iso-8859-10",
             "iso-8859-14",
             "iso-8859-16",
             "iso-8859-3",
-        ],
-        "iso-8859-16" => vec![
+        ]),
+        ("iso-8859-16", vec![
             "iso-8859-14",
             "iso-8859-15",
             "iso-8859-2",
             "iso-8859-3",
             "windows-1254",
             "windows-1252",
-        ],
-        "iso-8859-2" => vec![
+        ]),
+        ("iso-8859-2", vec![
             "iso-8859-16",
             "iso-8859-4",
-        ],
-        "iso-8859-3" => vec![
+        ]),
+        ("iso-8859-3", vec![
             "iso-8859-14",
             "iso-8859-15",
             "iso-8859-16",
             "windows-1254",
             "windows-1252",
-        ],
-        "iso-8859-4" => vec![
+        ]),
+        ("iso-8859-4", vec![
             "iso-8859-10",
             "iso-8859-2",
             "windows-1254",
             "windows-1252",
-        ],
-        "iso-8859-7" => vec![
+        ]),
+        ("iso-8859-7", vec![
             "windows-1253"
-        ],
-        "windows-1254" => vec![
+        ]),
+        ("windows-1254", vec![
             "windows-1252",
             "windows-1258",
             "iso-8859-10",
@@ -448,8 +445,8 @@ lazy_static! {
             "iso-8859-16",
             "iso-8859-3",
             "iso-8859-4",
-        ],
-        "windows-1252" => vec![
+        ]),
+        ("windows-1252", vec![
             "windows-1254",
             "windows-1258",
             "iso-8859-10",
@@ -458,6 +455,6 @@ lazy_static! {
             "iso-8859-16",
             "iso-8859-3",
             "iso-8859-4",
-        ],
-    };
+        ]),
+    ]);
 }

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -315,6 +315,7 @@ lazy_static! {
         "Block",
         "Shapes",
         "Supplemental",
+        "Supplement",
         "Tags",
     ]);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -582,8 +582,8 @@ pub fn from_bytes(bytes: &Vec<u8>, settings: Option<NormalizerSettings>) -> Char
         } else if fallback_u8.is_some()
             && (fallback_ascii.is_none()
                 || (fallback_ascii.is_some()
-                    && fallback_u8.as_ref().unwrap().fingerprint()
-                        != fallback_ascii.as_ref().unwrap().fingerprint()))
+                    && fallback_u8.as_ref().unwrap().decoded_payload()
+                        != fallback_ascii.as_ref().unwrap().decoded_payload()))
         {
             fb = Some(fallback_u8.as_ref().unwrap());
         } else if fallback_ascii.is_some() {

--- a/src/md.rs
+++ b/src/md.rs
@@ -6,9 +6,8 @@ use crate::utils::{
     is_katakana, is_latin, is_punctuation, is_separator, is_suspiciously_successive_range,
     is_symbol, is_thai, is_unprintable, remove_accent, unicode_range,
 };
-use cache_macro_stable_rust::cache;
+use cached::proc_macro::cached;
 use log::trace;
-use lru_cache::LruCache;
 use ordered_float::OrderedFloat;
 
 //
@@ -466,7 +465,7 @@ impl MessDetectorPlugin for ArchaicUpperLowerPlugin {
 }
 
 // Compute a mess ratio given a decoded bytes sequence. The maximum threshold does stop the computation earlier.
-#[cache(LruCache: LruCache::new(2048))]
+#[cached(size = 2048)]
 pub(crate) fn mess_ratio(
     decoded_sequence: String,
     maximum_threshold: Option<OrderedFloat<f32>>,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,18 +3,17 @@
 use crate::assets::*;
 use crate::consts::*;
 use crate::entity::*;
+use ahash::{HashSet, HashSetExt};
+use cached::proc_macro::cached;
+use cached::SizedCache;
 use encoding::label::encoding_from_whatwg_label;
 use encoding::{CodecError, DecoderTrap, EncoderTrap, Encoding, EncodingRef, StringWriter};
 use std::borrow::Cow;
-use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use unic::char::property::EnumeratedCharProperty;
 use unic::ucd::normal::decompose_canonical;
 use unic::ucd::{GeneralCategory, Name};
-
-use cache_macro_stable_rust::cache;
-use lru_cache::LruCache;
 
 // Utils module
 
@@ -54,22 +53,38 @@ fn in_description(character: &char, patterns: &[&str]) -> bool {
         .unwrap_or(false)
 }
 
-#[cache(LruCache: LruCache::new(*UTF8_MAXIMAL_ALLOCATION))]
+#[cached(
+    type = "SizedCache<char, bool>",
+    create = "{ SizedCache::with_size(*UTF8_MAXIMAL_ALLOCATION) }",
+    convert = r#"{ *character }"#
+)]
 pub(crate) fn is_punctuation(character: &char) -> bool {
     in_category(character, &[], &["P"], &["Punctuation"])
 }
 
-#[cache(LruCache: LruCache::new(*UTF8_MAXIMAL_ALLOCATION))]
+#[cached(
+    type = "SizedCache<char, bool>",
+    create = "{ SizedCache::with_size(*UTF8_MAXIMAL_ALLOCATION) }",
+    convert = r#"{ *character }"#
+)]
 pub(crate) fn is_symbol(character: &char) -> bool {
     in_category(character, &[], &["N", "S"], &["Forms"])
 }
 
-//#[cache(LruCache: LruCache::new(*UTF8_MAXIMAL_ALLOCATION))]
+#[cached(
+    type = "SizedCache<char, bool>",
+    create = "{ SizedCache::with_size(*UTF8_MAXIMAL_ALLOCATION) }",
+    convert = r#"{ *character }"#
+)]
 pub(crate) fn is_emoticon(character: &char) -> bool {
     in_category(character, &[], &[], &["Emoticons"])
 }
 
-#[cache(LruCache: LruCache::new(*UTF8_MAXIMAL_ALLOCATION))]
+#[cached(
+    type = "SizedCache<char, bool>",
+    create = "{ SizedCache::with_size(*UTF8_MAXIMAL_ALLOCATION) }",
+    convert = r#"{ *character }"#
+)]
 pub(crate) fn is_separator(character: &char) -> bool {
     if character.is_whitespace() || ['｜', '+', '<', '>'].contains(character) {
         return true;
@@ -77,7 +92,11 @@ pub(crate) fn is_separator(character: &char) -> bool {
     in_category(character, &["Po", "Pd", "Pc"], &["Z"], &[])
 }
 
-//#[cache(LruCache: LruCache::new(*UTF8_MAXIMAL_ALLOCATION))]
+#[cached(
+    type = "SizedCache<char, bool>",
+    create = "{ SizedCache::with_size(*UTF8_MAXIMAL_ALLOCATION) }",
+    convert = r#"{ *character }"#
+)]
 pub(crate) fn is_unprintable(character: &char) -> bool {
     !character.is_whitespace()
         && !character.is_ascii_graphic()
@@ -85,7 +104,11 @@ pub(crate) fn is_unprintable(character: &char) -> bool {
         && in_category(character, &["Cc"], &[], &["Control character"])
 }
 
-#[cache(LruCache: LruCache::new(*UTF8_MAXIMAL_ALLOCATION))]
+#[cached(
+    type = "SizedCache<char, bool>",
+    create = "{ SizedCache::with_size(*UTF8_MAXIMAL_ALLOCATION) }",
+    convert = r#"{ *character }"#
+)]
 pub(crate) fn is_accentuated(character: &char) -> bool {
     let patterns = [
         "WITH GRAVE",
@@ -98,43 +121,66 @@ pub(crate) fn is_accentuated(character: &char) -> bool {
     in_description(character, &patterns)
 }
 
-#[cache(LruCache: LruCache::new(*UTF8_MAXIMAL_ALLOCATION))]
+#[cached(
+    type = "SizedCache<char, bool>",
+    create = "{ SizedCache::with_size(*UTF8_MAXIMAL_ALLOCATION) }",
+    convert = r#"{ *character }"#
+)]
 pub(crate) fn is_latin(character: &char) -> bool {
     let patterns = ["LATIN"];
     in_description(character, &patterns)
 }
 
-#[cache(LruCache: LruCache::new(*UTF8_MAXIMAL_ALLOCATION))]
+#[cached(
+    type = "SizedCache<char, bool>",
+    create = "{ SizedCache::with_size(*UTF8_MAXIMAL_ALLOCATION) }",
+    convert = r#"{ *character }"#
+)]
 pub(crate) fn is_cjk(character: &char) -> bool {
     let patterns = ["CJK"];
     in_description(character, &patterns)
 }
 
-#[cache(LruCache: LruCache::new(*UTF8_MAXIMAL_ALLOCATION))]
+#[cached(
+    type = "SizedCache<char, bool>",
+    create = "{ SizedCache::with_size(*UTF8_MAXIMAL_ALLOCATION) }",
+    convert = r#"{ *character }"#
+)]
 pub(crate) fn is_hiragana(character: &char) -> bool {
     let patterns = ["HIRAGANA"];
     in_description(character, &patterns)
 }
 
-#[cache(LruCache: LruCache::new(*UTF8_MAXIMAL_ALLOCATION))]
+#[cached(
+    type = "SizedCache<char, bool>",
+    create = "{ SizedCache::with_size(*UTF8_MAXIMAL_ALLOCATION) }",
+    convert = r#"{ *character }"#
+)]
 pub(crate) fn is_katakana(character: &char) -> bool {
     let patterns = ["KATAKANA"];
     in_description(character, &patterns)
 }
 
-#[cache(LruCache: LruCache::new(*UTF8_MAXIMAL_ALLOCATION))]
+#[cached(
+    type = "SizedCache<char, bool>",
+    create = "{ SizedCache::with_size(*UTF8_MAXIMAL_ALLOCATION) }",
+    convert = r#"{ *character }"#
+)]
 pub(crate) fn is_hangul(character: &char) -> bool {
     let patterns = ["HANGUL"];
     in_description(character, &patterns)
 }
 
-#[cache(LruCache: LruCache::new(*UTF8_MAXIMAL_ALLOCATION))]
+#[cached(
+    type = "SizedCache<char, bool>",
+    create = "{ SizedCache::with_size(*UTF8_MAXIMAL_ALLOCATION) }",
+    convert = r#"{ *character }"#
+)]
 pub(crate) fn is_thai(character: &char) -> bool {
     let patterns = ["THAI"];
     in_description(character, &patterns)
 }
 
-//#[cache(LruCache: LruCache::new(*UTF8_MAXIMAL_ALLOCATION))]
 pub(crate) fn is_case_variable(character: &char) -> bool {
     character.is_lowercase() != character.is_uppercase()
 }
@@ -146,7 +192,6 @@ pub(crate) fn is_unicode_range_secondary(range_name: String) -> bool {
 }
 
 // Retrieve the Unicode range official name from a single character
-//#[cache(LruCache: LruCache::new(*UTF8_MAXIMAL_ALLOCATION))]
 pub(crate) fn unicode_range(character: &char) -> Option<&'static str> {
     let char_code = *character as u32;
     for (name, range) in &*UNICODE_RANGES_COMBINED {
@@ -167,12 +212,10 @@ pub(crate) fn range_scan(decoded_sequence: &str) -> HashSet<String> {
     result
 }
 
-//#[cache(LruCache: LruCache::new(*UTF8_MAXIMAL_ALLOCATION))]
 pub(crate) fn is_ascii(character: &char) -> bool {
     character.is_ascii()
 }
 
-//#[cache(LruCache: LruCache::new(*UTF8_MAXIMAL_ALLOCATION))]
 pub(crate) fn remove_accent(ch: &char) -> char {
     let mut base_char = None;
     decompose_canonical(*ch, |c| {
@@ -418,7 +461,6 @@ pub fn encode(
 }
 
 // Determine if two Unicode range seen next to each other can be considered as suspicious.
-#[cache(LruCache: LruCache::new(1024))]
 pub(crate) fn is_suspiciously_successive_range(
     range_a: Option<&'static str>,
     range_b: Option<&'static str>,


### PR DESCRIPTION
Using alternative hash function for HashMaps, HashSets & LRU caching.

Faster by 10-30% (depends on hardware and platform).