### PR TITLE
Lint fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "charset-normalizer-rs"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "ahash",
  "assert_cmd",

--- a/src/cd.rs
+++ b/src/cd.rs
@@ -110,7 +110,7 @@ pub(crate) fn alphabet_languages(
         let language_characters_set: HashSet<_> = language_characters.chars().collect();
         let intersection: HashSet<_> = language_characters_set
             .intersection(&source_characters_set)
-            .cloned()
+            .copied()
             .collect();
 
         let ratio: f32 = intersection.len() as f32 / language_characters_set.len() as f32;
@@ -244,7 +244,7 @@ pub(crate) fn coherence_ratio(
 
             if ratio < threshold {
                 continue;
-            } 
+            }
             if ratio >= 0.8 {
                 sufficient_match_count += 1;
             }

--- a/src/cd.rs
+++ b/src/cd.rs
@@ -244,7 +244,8 @@ pub(crate) fn coherence_ratio(
 
             if ratio < threshold {
                 continue;
-            } else if ratio >= 0.8 {
+            } 
+            if ratio >= 0.8 {
                 sufficient_match_count += 1;
             }
 

--- a/src/cd.rs
+++ b/src/cd.rs
@@ -1,8 +1,11 @@
 #![allow(unused_variables)]
-use crate::assets::*;
+use crate::assets::{ENCODING_TO_LANGUAGE, LANGUAGES};
 use crate::consts::TOO_SMALL_SEQUENCE;
-use crate::entity::*;
-use crate::utils::*;
+use crate::entity::{CoherenceMatch, CoherenceMatches, Language};
+use crate::utils::{
+    get_language_data, is_accentuated, is_multi_byte_encoding, is_suspiciously_successive_range,
+    is_unicode_range_secondary, unicode_range,
+};
 use ahash::{HashMap, HashMapExt, HashSet};
 use cached::proc_macro::cached;
 use counter::Counter;

--- a/src/normalizer.rs
+++ b/src/normalizer.rs
@@ -57,7 +57,7 @@ fn normalizer(args: &CLINormalizerArgs) -> Result<i32, String> {
                         encoding_aliases: m
                             .encoding_aliases()
                             .iter()
-                            .map(|s| s.to_string())
+                            .map(|s| (*s).to_string())
                             .collect(),
                         alternative_encodings: m
                             .suitable_encodings()


### PR DESCRIPTION
Using `cargo clippy -- -Wclippy::pedantic` to find some further low hanging fruit.
The false positive rate is quite high, so I'm tempted to include some line allows like
`#![allow(cargo::range_plus_one)]`

However I'm not sure you would agree that it is a good idea since the default `cargo clippy` does not complain.
One compromise would be to have it enabled in a separate branch like `pedantic` or `dev` where we could use to merge recent fixes to look through the course in a strict(pedantic), yet context aware(we know some are false positives) way.