### PR TITLE
Fixes

### DIFF
--- a/src/cd.rs
+++ b/src/cd.rs
@@ -164,7 +164,7 @@ pub(crate) fn characters_popularity_compare(
 pub(crate) fn filter_alt_coherence_matches(results: &CoherenceMatches) -> CoherenceMatches {
     let mut index: HashMap<&Language, f32> = HashMap::with_capacity(results.len());
     for result in results {
-        let score = index.entry(result.language).or_insert(0.0);
+        let score = index.entry(result.language).or_default();
         *score = result.score.max(*score);
     }
     index

--- a/src/cd.rs
+++ b/src/cd.rs
@@ -29,17 +29,17 @@ pub(crate) fn encoding_unicode_range(iana_name: &str) -> Result<Vec<&str>, Strin
     let byte_range = 0x40..0xFF; // utf8 range. range.len()==191
     let mut result: HashMap<&str, u8> = HashMap::with_capacity(byte_range.len());
 
-    for i in byte_range {
-        encoder
+    byte_range.for_each(|i| {
+        if let Some(range) = encoder
             .decode(&[i], DecoderTrap::Ignore)
             .ok()
             .and_then(|chunk| chunk.chars().next())
             .and_then(|first_char| unicode_range(&first_char))
             .filter(|&range| !is_unicode_range_secondary(range))
-            .map(|range| {
-                *result.entry(range).or_insert(0) += 1;
-            });
-    }
+        {
+            *result.entry(range).or_insert(0) += 1;
+        }
+    });
     let character_count: u8 = result.values().sum();
     let threshold = 0.15;
     let mut result: Vec<&str> = result

--- a/src/cd.rs
+++ b/src/cd.rs
@@ -204,9 +204,8 @@ pub(crate) fn coherence_ratio(
     include_languages: Option<Vec<&'static Language>>,
 ) -> Result<CoherenceMatches, String> {
     let threshold = f32::from(threshold.unwrap_or(OrderedFloat(0.1)));
-    let mut include_languages = include_languages.unwrap_or_default();
-    let ignore_non_latin =
-        include_languages.len() == 1 && include_languages.first() == Some(&&Language::Unknown);
+    let mut include_languages: Vec<&Language> = include_languages.unwrap_or_default();
+    let ignore_non_latin = include_languages == vec![&Language::Unknown];
     if ignore_non_latin {
         include_languages.clear();
     }

--- a/src/cd.rs
+++ b/src/cd.rs
@@ -94,7 +94,7 @@ pub(crate) fn alphabet_languages(
     ignore_non_latin: bool,
 ) -> Vec<&'static Language> {
     let mut languages: Vec<(&Language, f32)> = vec![];
-    let source_characters_set: HashSet<_> = characters.iter().cloned().copied().collect();
+    let source_characters_set: HashSet<char> = characters.iter().copied().copied().collect(); //take a look why copied/cloned is needed twice
     let source_has_accents = source_characters_set.iter().any(is_accentuated);
 
     for (language, language_characters, target_have_accents, target_pure_latin) in LANGUAGES.iter()

--- a/src/cd.rs
+++ b/src/cd.rs
@@ -129,7 +129,8 @@ pub(crate) fn alpha_unicode_split(decoded_sequence: &str) -> Vec<String> {
 
     for ch in decoded_sequence.chars().filter(|c| c.is_alphabetic()) {
         if let Some(character_range) = unicode_range(&ch) {
-            let layer_key = layers.keys()
+            let layer_key: &str = layers
+                .keys()
                 .find(|key| !is_suspiciously_successive_range(Some(key), Some(character_range)))
                 .copied()
                 .unwrap_or(character_range);

--- a/src/cd.rs
+++ b/src/cd.rs
@@ -234,11 +234,10 @@ pub(crate) fn coherence_ratio(
             let ratio: f32 =
                 characters_popularity_compare(language, &popular_character_ordered_as_string)?;
 
-            if ratio < threshold {
-                continue;
-            }
-            if ratio >= 0.8 {
-                sufficient_match_count += 1;
+            match ratio {
+                r if r < threshold => continue,
+                r if r >= 0.8 => sufficient_match_count += 1,
+                _ => {}
             }
 
             results.push(CoherenceMatch {

--- a/src/cd.rs
+++ b/src/cd.rs
@@ -206,7 +206,7 @@ pub(crate) fn coherence_ratio(
     }
 
     let mut results: CoherenceMatches = vec![];
-    let mut sufficient_match_count: u8 = 0;
+    let mut sufficient_match_count: u64 = 0;
 
     for layer in alpha_unicode_split(&decoded_sequence) {
         if layer.chars().count() <= *TOO_SMALL_SEQUENCE {

--- a/src/cd.rs
+++ b/src/cd.rs
@@ -129,21 +129,15 @@ pub(crate) fn alpha_unicode_split(decoded_sequence: &str) -> Vec<String> {
 
     for ch in decoded_sequence.chars().filter(|c| c.is_alphabetic()) {
         if let Some(character_range) = unicode_range(&ch) {
-            let mut layer_target_range: Option<&str> = None;
-            for discovered_range in layers.keys() {
-                if !is_suspiciously_successive_range(Some(discovered_range), Some(character_range))
-                {
-                    layer_target_range = Some(discovered_range);
-                    break;
-                }
-            }
-            let layer = layers
-                .entry(layer_target_range.get_or_insert(character_range))
-                .or_default();
+            let layer_key = layers.keys()
+                .find(|key| !is_suspiciously_successive_range(Some(key), Some(character_range)))
+                .copied()
+                .unwrap_or(character_range);
+            let layer = layers.entry(layer_key).or_default();
             layer.extend(ch.to_lowercase());
         }
     }
-    layers.values().cloned().collect()
+    layers.into_values().collect()
 }
 
 // Determine if a ordered characters list (by occurrence from most appearance to rarest) match a particular language.

--- a/src/cd.rs
+++ b/src/cd.rs
@@ -211,7 +211,7 @@ pub(crate) fn coherence_ratio(
     }
 
     let mut results: CoherenceMatches = vec![];
-    let mut sufficient_match_count: u64 = 0;
+    let mut sufficient_match_count: u8 = 0;
 
     for layer in alpha_unicode_split(&decoded_sequence) {
         if layer.chars().count() <= *TOO_SMALL_SEQUENCE {

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -19,7 +19,7 @@ lazy_static! {
     pub static ref TOO_BIG_SEQUENCE: usize = 1_000_000; // 10E6
 
     pub(crate) static ref UTF8_MAXIMAL_ALLOCATION: usize = 128;
-    pub(crate) static ref UNICODE_RANGES_COMBINED: Vec<(&'static str, RangeInclusive<u32>)> = vec![
+    pub(crate) static ref UNICODE_RANGES_COMBINED: [(&'static str, RangeInclusive<u32>);279] = [
         ("Control character", 0..=31),
         ("Basic Latin", 32..=127),
         ("Latin-1 Supplement", 128..=255),

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -195,7 +195,7 @@ impl CharsetMatch {
                     } else {
                         encoding_languages(self.encoding.clone())
                     };
-                    languages.first().cloned().unwrap_or(&Language::Unknown)
+                    languages.first().copied().unwrap_or(&Language::Unknown)
                 }
             },
             |lang| lang.language,

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -159,7 +159,7 @@ impl CharsetMatch {
     }
 
     // Add submatch
-    pub fn add_submatch(&mut self, submatch: CharsetMatch) {
+    pub fn add_submatch(&mut self, submatch: &CharsetMatch) {
         self.submatch.push(submatch.clone());
         //self.decoded_payload = None;
     }
@@ -303,7 +303,7 @@ impl CharsetMatches {
                 if m.decoded_payload() == item.decoded_payload()
                     && m.mean_mess_ratio == item.mean_mess_ratio
                 {
-                    m.add_submatch(item.clone());
+                    m.add_submatch(&item);
                     return;
                 }
             }

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -299,9 +299,9 @@ impl CharsetMatches {
         // We should disable the submatch factoring when the input file is too heavy
         // (conserve RAM usage)
         if item.payload.len() <= *TOO_BIG_SEQUENCE {
-            for m in self.items.iter_mut() {
+            for m in &mut self.items {
                 if m.decoded_payload() == item.decoded_payload()
-                    && m.mean_mess_ratio == item.mean_mess_ratio
+                    && (m.mean_mess_ratio - item.mean_mess_ratio).abs() < f32::EPSILON
                 {
                     m.add_submatch(&item);
                     return;

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -184,22 +184,22 @@ impl CharsetMatch {
     // Most probable language found in decoded sequence. If none were detected or inferred, the property will return
     // Language::Unknown
     pub fn most_probably_language(&self) -> &'static Language {
-        self.coherence_matches
-            .first()
-            .map(|lang| lang.language)
-            .unwrap_or_else(|| {
-                // Trying to infer the language based on the given encoding
-                // It's either English or we should not pronounce ourselves in certain cases.
+        self.coherence_matches.first().map_or_else(
+            // Default case: Trying to infer the language based on the given encoding
+            || {
                 if self.suitable_encodings().contains(&String::from("ascii")) {
-                    return &Language::English;
-                }
-                let languages = if is_multi_byte_encoding(&self.encoding) {
-                    mb_encoding_languages(&self.encoding)
+                    &Language::English
                 } else {
-                    encoding_languages(self.encoding.clone())
-                };
-                languages.first().unwrap_or(&&Language::Unknown)
-            })
+                    let languages = if is_multi_byte_encoding(&self.encoding) {
+                        mb_encoding_languages(&self.encoding)
+                    } else {
+                        encoding_languages(self.encoding.clone())
+                    };
+                    languages.first().cloned().unwrap_or(&Language::Unknown)
+                }
+            },
+            |lang| lang.language,
+        )
     }
     // Return the complete list of possible languages found in decoded sequence.
     // Usually not really useful. Returned list may be empty even if 'language' property return something != 'Unknown'.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -526,15 +526,14 @@ pub fn from_bytes(bytes: &[u8], settings: Option<NormalizerSettings>) -> Charset
         // Most of the time its not relevant to run "language-detection" on it.
         let mut cd_ratios: Vec<CoherenceMatches> = vec![];
         if encoding_iana != "ascii" {
-            for chunk in md_chunks {
-                if let Ok(chunk_coherence_matches) = coherence_ratio(
-                    chunk,
+            cd_ratios.extend(md_chunks.iter().filter_map(|chunk| {
+                coherence_ratio(
+                    chunk.clone(),
                     Some(settings.language_threshold),
                     Some(target_languages.clone()),
-                ) {
-                    cd_ratios.push(chunk_coherence_matches);
-                }
-            }
+                )
+                .ok()
+            }));
         }
 
         // process cd ratios

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,7 @@ use crate::utils::{
 };
 use encoding::DecoderTrap;
 use log::{debug, trace};
+use std::collections::VecDeque;
 use std::fs::{metadata, File};
 use std::io::Read;
 use std::path::Path;
@@ -274,14 +275,14 @@ pub fn from_bytes(bytes: &[u8], settings: Option<NormalizerSettings>) -> Charset
     }
 
     // add ascii & utf-8
-    prioritized_encodings.extend(["ascii", "utf-8"].iter().map(|&s| s.to_string()));
+    prioritized_encodings.extend(["ascii".to_string(), "utf-8".to_string()]);
 
     // generate array of encodings for probing with prioritizing
-    let mut iana_encodings = IANA_SUPPORTED.clone();
+    let mut iana_encodings: VecDeque<&str> = VecDeque::from(IANA_SUPPORTED.clone());
     for pe in prioritized_encodings.iter().rev() {
         if let Some(index) = iana_encodings.iter().position(|x| *x == pe) {
-            let value = iana_encodings.remove(index);
-            iana_encodings.insert(0, value);
+            let value = iana_encodings.remove(index).unwrap();
+            iana_encodings.push_front(value);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,8 @@ use std::io::Read;
 use std::path::Path;
 
 pub mod assets;
-#[allow(clippy::cast_lossless)] // TODO: Revisit float conversions when we want to push for accuracy
+// TODO: Revisit float conversions when we want to push for accuracy
+#[allow(clippy::cast_lossless, clippy::cast_precision_loss)]
 mod cd;
 pub mod consts;
 pub mod entity;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,7 @@ use std::io::Read;
 use std::path::Path;
 
 pub mod assets;
+#[allow(clippy::cast_lossless)] // TODO: Revisit float conversions when we want to push for accuracy
 mod cd;
 pub mod consts;
 pub mod entity;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,7 +272,7 @@ pub fn from_bytes(bytes: &[u8], settings: Option<NormalizerSettings>) -> Charset
     }
 
     // add ascii & utf-8
-    prioritized_encodings.extend(["ascii", "utf-8"].iter().map(|s| s.to_string()));
+    prioritized_encodings.extend(["ascii", "utf-8"].iter().map(|&s| s.to_string()));
 
     // generate array of encodings for probing with prioritizing
     let mut iana_encodings = IANA_SUPPORTED.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -507,12 +507,10 @@ pub fn from_bytes(bytes: &[u8], settings: Option<NormalizerSettings>) -> Charset
                     decoded_payload,
                 ));
 
-                if encoding_iana == specified_encoding {
-                    fallback_specified = fallback_entry;
-                } else if encoding_iana == "ascii" {
-                    fallback_ascii = fallback_entry;
-                } else {
-                    fallback_u8 = fallback_entry;
+                match encoding_iana {
+                    e if e == specified_encoding => fallback_specified = fallback_entry,
+                    "ascii" => fallback_ascii = fallback_entry,
+                    _ => fallback_u8 = fallback_entry,
                 }
             }
             continue 'iana_encodings_loop;

--- a/src/md.rs
+++ b/src/md.rs
@@ -69,7 +69,7 @@ impl MessDetectorPlugin for TooManySymbolOrPunctuationPlugin {
         let ratio_of_punctuation =
             (self.punctuation_count + self.symbol_count) as f32 / (self.character_count as f32);
         (ratio_of_punctuation >= 0.3)
-            .then(|| ratio_of_punctuation)
+            .then_some(ratio_of_punctuation)
             .unwrap_or(0.0)
     }
 }

--- a/src/md.rs
+++ b/src/md.rs
@@ -68,9 +68,11 @@ impl MessDetectorPlugin for TooManySymbolOrPunctuationPlugin {
         }
         let ratio_of_punctuation =
             (self.punctuation_count + self.symbol_count) as f32 / (self.character_count as f32);
-        (ratio_of_punctuation >= 0.3)
-            .then_some(ratio_of_punctuation)
-            .unwrap_or(0.0)
+        if ratio_of_punctuation >= 0.3 {
+            ratio_of_punctuation
+        } else {
+            0.0
+        }
     }
 }
 

--- a/src/md.rs
+++ b/src/md.rs
@@ -467,11 +467,10 @@ pub(crate) fn mess_ratio(
         .chain(std::iter::once('\n'))
         .enumerate()
     {
-        for detector in &mut *detectors {
-            if detector.eligible(ch) {
-                detector.feed(&ch);
-            }
-        }
+        detectors
+            .iter_mut()
+            .filter(|detector| detector.eligible(ch))
+            .for_each(|detector| detector.feed(&ch));
 
         if (index > 0 && index.rem_euclid(intermediary_mean_mess_ratio_calc) == 0)
             || index == length

--- a/src/md.rs
+++ b/src/md.rs
@@ -213,7 +213,7 @@ impl MessDetectorPlugin for SuspiciousRangePlugin {
         (self.character_count > 0)
             .then_some(
                 ((self.suspicious_successive_range_count as f32) * 2.0)
-                    / self.character_count as f32
+                    / self.character_count as f32,
             )
             .filter(|&ratio| ratio >= 0.1)
             .unwrap_or(0.0)

--- a/src/normalizer.rs
+++ b/src/normalizer.rs
@@ -131,7 +131,7 @@ fn normalizer(args: &CLINormalizerArgs) -> Result<i32, String> {
     // print out results
     if args.minimal {
         for path in &args.files {
-            let full_path = fs::canonicalize(path).unwrap();
+            let full_path = fs::canonicalize(path).map_err(|err| err.to_string())?;
             println!(
                 "{}",
                 results

--- a/src/tests/detection_base.rs
+++ b/src/tests/detection_base.rs
@@ -129,7 +129,7 @@ fn test_obviously_ascii_content() {
     ];
 
     for input in tests {
-        let result = from_bytes(&input.to_vec(), None);
+        let result = from_bytes(input, None);
         let best_guess = result.get_best();
         assert!(
             best_guess.is_some(),
@@ -161,7 +161,7 @@ fn test_obviously_utf8_content() {
     ];
 
     for input in tests {
-        let result = from_bytes(&input.as_bytes().to_vec(), None);
+        let result = from_bytes(input.as_bytes(), None);
         let best_guess = result.get_best();
         assert!(
             best_guess.is_some(),
@@ -180,7 +180,7 @@ fn test_obviously_utf8_content() {
 #[test]
 fn test_unicode_ranges_property() {
     let text = "😀 Hello World! How affairs are going? 😀";
-    let result = from_bytes(&text.as_bytes().to_vec(), None);
+    let result = from_bytes(text.as_bytes(), None);
     let best_guess = result.get_best();
     let ur = best_guess.unwrap().unicode_ranges();
     assert!(ur.contains(&"Basic Latin".to_string()));
@@ -192,7 +192,7 @@ fn test_mb_cutting_chk() {
     let payload = b"\xbf\xaa\xbb\xe7\xc0\xfb    \xbf\xb9\xbc\xf6    \xbf\xac\xb1\xb8\xc0\xda\xb5\xe9\xc0\xba  \xba\xb9\xc0\xbd\xbc\xad\xb3\xaa ".repeat(128);
     let mut settings = NormalizerSettings::default();
     settings.include_encodings.push(String::from("euc-kr"));
-    let result = from_bytes(&payload.as_slice().to_vec(), Some(settings));
+    let result = from_bytes(payload.as_slice(), Some(settings));
     let best_guess = result.get_best().unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(best_guess.encoding(), "euc-kr");

--- a/src/tests/detection_edge_case.rs
+++ b/src/tests/detection_edge_case.rs
@@ -5,7 +5,7 @@ fn test_undefined_unicode_ranges() {
     let tests = [b"\xef\xbb\xbf\xf0\x9f\xa9\xb3".as_slice()];
 
     for input in tests {
-        let result = from_bytes(&input.to_vec(), None);
+        let result = from_bytes(input, None);
         let best_guess = result.get_best();
         assert!(
             best_guess.is_some(),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -48,12 +48,11 @@ fn in_category(
 // check if character description contains at least one of patterns
 fn in_description(character: &char, patterns: &[&str]) -> bool {
     Name::of(*character)
-        .map(|description| {
+        .is_some_and(|description| {
             patterns
                 .iter()
                 .any(|&s| description.to_string().contains(s))
         })
-        .unwrap_or(false)
 }
 
 #[cached(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,11 @@
 #![allow(dead_code)]
 
-use crate::assets::*;
-use crate::consts::*;
-use crate::entity::*;
+use crate::assets::LANGUAGES;
+use crate::consts::{
+    ENCODING_MARKS, IANA_SUPPORTED, IANA_SUPPORTED_SIMILAR, RE_POSSIBLE_ENCODING_INDICATION,
+    UNICODE_RANGES_COMBINED, UNICODE_SECONDARY_RANGE_KEYWORD, UTF8_MAXIMAL_ALLOCATION,
+};
+use crate::entity::Language;
 use ahash::{HashSet, HashSetExt};
 use cached::proc_macro::cached;
 use cached::UnboundCache;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -249,8 +249,7 @@ pub(crate) fn identify_sig_or_bom(sequence: &[u8]) -> (Option<String>, Option<&[
     ENCODING_MARKS
         .iter()
         .find(|&(_, enc_sig)| sequence.starts_with(enc_sig))
-        .map(|(enc_name, enc_sig)| (Some(enc_name.to_string()), Some(*enc_sig)))
-        .unwrap_or((None, None))
+        .map_or((None, None), |(enc_name, enc_sig)| (Some(enc_name.to_string()), Some(*enc_sig)))
 }
 
 // Try to get standard name by alternative labels

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -280,7 +280,8 @@ pub(crate) fn any_specified_encoding(sequence: &[u8], search_zone: usize) -> Opt
         .and_then(|test_string| {
             RE_POSSIBLE_ENCODING_INDICATION
                 .captures_iter(&test_string)
-                .map(|c| c.extract()).find_map(|(_, [specified_encoding])| iana_name(specified_encoding))
+                .map(|c| c.extract())
+                .find_map(|(_, [specified_encoding])| iana_name(specified_encoding))
                 .map(|found_iana| found_iana.to_string())
         })
 }


### PR DESCRIPTION
Being more strict with `cargo clippy` and `cargo test`
looking more into `cargo clippy -- -Wclippy::pedantic`

As said before, pedantic is just that. Pedantic. There are many false positives and we don't need to fix all of them.
But it still would be valuable to understand why they are false positives and document them if necessary.