### PR TITLE
Trivially copy pass by ref

### DIFF
--- a/src/cd.rs
+++ b/src/cd.rs
@@ -34,7 +34,7 @@ pub(crate) fn encoding_unicode_range(iana_name: &str) -> Result<Vec<&str>, Strin
             .decode(&[i], DecoderTrap::Ignore)
             .ok()
             .and_then(|chunk| chunk.chars().next())
-            .and_then(|first_char| unicode_range(first_char))
+            .and_then(unicode_range)
             .filter(|&range| !is_unicode_range_secondary(range))
         {
             *result.entry(range).or_insert(0) += 1;

--- a/src/cd.rs
+++ b/src/cd.rs
@@ -90,7 +90,7 @@ pub(crate) fn mb_encoding_languages(iana_name: &str) -> Vec<&'static Language> {
 // Return associated languages associated to given characters
 #[allow(clippy::ptr_arg)]
 pub(crate) fn alphabet_languages(
-    characters: Vec<char>,
+    characters: &[char],
     ignore_non_latin: bool,
 ) -> Vec<&'static Language> {
     let mut languages: Vec<(&Language, f32)> = vec![];
@@ -224,7 +224,7 @@ pub(crate) fn coherence_ratio(
         let popular_character_ordered: Vec<char> = most_common.iter().map(|(ch, _)| *ch).collect();
 
         let languages = if include_languages.is_empty() {
-            alphabet_languages(popular_character_ordered.clone(), ignore_non_latin)
+            alphabet_languages(&popular_character_ordered, ignore_non_latin)
         } else {
             include_languages.clone()
         };
@@ -234,10 +234,8 @@ pub(crate) fn coherence_ratio(
 
         // Convert the String into a &str
         for language in languages {
-            let ratio: f32 = characters_popularity_compare(
-                language,
-                &popular_character_ordered_as_string,
-            )?;
+            let ratio: f32 =
+                characters_popularity_compare(language, &popular_character_ordered_as_string)?;
 
             if ratio < threshold {
                 continue;

--- a/src/cd.rs
+++ b/src/cd.rs
@@ -230,7 +230,7 @@ pub(crate) fn coherence_ratio(
         };
 
         let popular_character_ordered_as_string: String =
-            popular_character_ordered.into_iter().collect();
+            popular_character_ordered.iter().collect();
 
         // Convert the String into a &str
         for language in languages {

--- a/src/cd.rs
+++ b/src/cd.rs
@@ -229,8 +229,8 @@ pub(crate) fn coherence_ratio(
             include_languages.clone()
         };
 
-        let popular_character_ordered_as_string =
-            popular_character_ordered.into_iter().collect::<String>();
+        let popular_character_ordered_as_string: String =
+            popular_character_ordered.into_iter().collect();
 
         // Convert the String into a &str
         for language in languages {

--- a/src/cd.rs
+++ b/src/cd.rs
@@ -236,7 +236,7 @@ pub(crate) fn coherence_ratio(
         for language in languages {
             let ratio: f32 = characters_popularity_compare(
                 language,
-                popular_character_ordered_as_string.as_str(),
+                &popular_character_ordered_as_string,
             )?;
 
             if ratio < threshold {

--- a/src/cd.rs
+++ b/src/cd.rs
@@ -130,7 +130,7 @@ pub(crate) fn alpha_unicode_split(decoded_sequence: &str) -> Vec<String> {
     let mut layers: HashMap<&str, String> = HashMap::new();
 
     for ch in decoded_sequence.chars().filter(|c| c.is_alphabetic()) {
-        if let Some(character_range) = unicode_range(&ch) {
+        if let Some(character_range) = unicode_range(ch) {
             let layer_key: &str = layers
                 .keys()
                 .find(|key| !is_suspiciously_successive_range(Some(key), Some(character_range)))

--- a/src/md.rs
+++ b/src/md.rs
@@ -470,7 +470,7 @@ pub(crate) fn mess_ratio(
         detectors
             .iter_mut()
             .filter(|detector| detector.eligible(ch))
-            .for_each(|detector| detector.feed(&ch));
+            .for_each(|detector| detector.feed(ch));
 
         if (index > 0 && index.rem_euclid(intermediary_mean_mess_ratio_calc) == 0)
             || index == length

--- a/src/md.rs
+++ b/src/md.rs
@@ -23,11 +23,11 @@ trait MessDetectorPlugin {
     }
 
     // Determine if given character should be fed in
-    fn eligible(&self, character: &char) -> bool;
+    fn eligible(&self, character: char) -> bool;
 
     // The main routine to be executed upon character.
     // Insert the logic in witch the text would be considered chaotic.
-    fn feed(&mut self, character: &char);
+    fn feed(&mut self, character: char);
 
     // Compute the chaos ratio based on what your feed() has seen.
     // Must NOT be lower than 0.; No restriction gt 0.
@@ -46,13 +46,13 @@ struct TooManySymbolOrPunctuationPlugin {
 }
 
 impl MessDetectorPlugin for TooManySymbolOrPunctuationPlugin {
-    fn eligible(&self, character: &char) -> bool {
+    fn eligible(&self, character: char) -> bool {
         !is_unprintable(character)
     }
-    fn feed(&mut self, character: &char) {
+    fn feed(&mut self, character: char) {
         self.character_count += 1;
-        if (self.last_printable_char.is_none() || *character != self.last_printable_char.unwrap())
-            && !COMMON_SAFE_ASCII_CHARACTERS.contains(*character)
+        if (self.last_printable_char.is_none() || character != self.last_printable_char.unwrap())
+            && !COMMON_SAFE_ASCII_CHARACTERS.contains(character)
         {
             if is_punctuation(character) {
                 self.punctuation_count += 1;
@@ -60,7 +60,7 @@ impl MessDetectorPlugin for TooManySymbolOrPunctuationPlugin {
                 self.symbol_count += 2;
             }
         }
-        self.last_printable_char = Some(*character);
+        self.last_printable_char = Some(character);
     }
     fn ratio(&self) -> f32 {
         if self.character_count == 0 {
@@ -85,10 +85,10 @@ struct TooManyAccentuatedPlugin {
 }
 
 impl MessDetectorPlugin for TooManyAccentuatedPlugin {
-    fn eligible(&self, character: &char) -> bool {
+    fn eligible(&self, character: char) -> bool {
         character.is_alphabetic()
     }
-    fn feed(&mut self, character: &char) {
+    fn feed(&mut self, character: char) {
         self.character_count += 1;
         if is_accentuated(character) {
             self.accentuated_count += 1
@@ -113,10 +113,10 @@ struct UnprintablePlugin {
 }
 
 impl MessDetectorPlugin for UnprintablePlugin {
-    fn eligible(&self, character: &char) -> bool {
+    fn eligible(&self, character: char) -> bool {
         true
     }
-    fn feed(&mut self, character: &char) {
+    fn feed(&mut self, character: char) {
         if is_unprintable(character) {
             self.unprintable_count += 1;
         }
@@ -141,25 +141,25 @@ struct SuspiciousDuplicateAccentPlugin {
 }
 
 impl MessDetectorPlugin for SuspiciousDuplicateAccentPlugin {
-    fn eligible(&self, character: &char) -> bool {
+    fn eligible(&self, character: char) -> bool {
         character.is_alphabetic() && is_latin(character)
     }
-    fn feed(&mut self, character: &char) {
+    fn feed(&mut self, character: char) {
         self.character_count += 1;
         if self.last_latin_character.is_some()
             && is_accentuated(character)
-            && is_accentuated(&self.last_latin_character.unwrap())
+            && is_accentuated(self.last_latin_character.unwrap())
         {
             if character.is_uppercase() && self.last_latin_character.unwrap().is_uppercase() {
                 self.successive_count += 1;
             }
 
             // Worse if its the same char duplicated with different accent.
-            if remove_accent(character) == remove_accent(&self.last_latin_character.unwrap()) {
+            if remove_accent(character) == remove_accent(self.last_latin_character.unwrap()) {
                 self.successive_count += 1;
             }
         }
-        self.last_latin_character = Some(*character);
+        self.last_latin_character = Some(character);
     }
     fn ratio(&self) -> f32 {
         if self.character_count == 0 {
@@ -180,26 +180,26 @@ struct SuspiciousRangePlugin {
 }
 
 impl MessDetectorPlugin for SuspiciousRangePlugin {
-    fn eligible(&self, character: &char) -> bool {
+    fn eligible(&self, character: char) -> bool {
         !is_unprintable(character)
     }
-    fn feed(&mut self, character: &char) {
+    fn feed(&mut self, character: char) {
         self.character_count += 1;
 
         if character.is_whitespace()
             || is_punctuation(character)
-            || COMMON_SAFE_ASCII_CHARACTERS.contains(*character)
+            || COMMON_SAFE_ASCII_CHARACTERS.contains(character)
         {
             self.last_printable_char = None;
             return;
         }
 
         if self.last_printable_char.is_none() {
-            self.last_printable_char = Some(*character);
+            self.last_printable_char = Some(character);
             return;
         }
 
-        let tmp_a = &self.last_printable_char.unwrap();
+        let tmp_a = self.last_printable_char.unwrap();
         let unicode_range_a = unicode_range(tmp_a);
         let unicode_range_b = unicode_range(character);
 
@@ -207,7 +207,7 @@ impl MessDetectorPlugin for SuspiciousRangePlugin {
             self.suspicious_successive_range_count += 1;
         }
 
-        self.last_printable_char = Some(*character);
+        self.last_printable_char = Some(character);
     }
     fn ratio(&self) -> f32 {
         (self.character_count > 0)
@@ -238,12 +238,12 @@ struct SuperWeirdWordPlugin {
 }
 
 impl MessDetectorPlugin for SuperWeirdWordPlugin {
-    fn eligible(&self, character: &char) -> bool {
+    fn eligible(&self, character: char) -> bool {
         true
     }
-    fn feed(&mut self, character: &char) {
+    fn feed(&mut self, character: char) {
         if character.is_ascii_alphabetic() {
-            self.buffer.push(*character);
+            self.buffer.push(character);
             if is_accentuated(character) {
                 self.buffer_accent_count += 1;
             }
@@ -276,7 +276,7 @@ impl MessDetectorPlugin for SuperWeirdWordPlugin {
                 // Word/Buffer ending with an upper case accentuated letter are so rare,
                 // that we will consider them all as suspicious. Same weight as foreign_long suspicious.
                 let last_char = self.buffer.chars().last().unwrap();
-                if is_accentuated(&last_char) && last_char.is_uppercase() {
+                if is_accentuated(last_char) && last_char.is_uppercase() {
                     self.foreign_long_count += 1;
                     self.is_current_word_bad = true;
                 }
@@ -304,12 +304,12 @@ impl MessDetectorPlugin for SuperWeirdWordPlugin {
             self.foreign_long_watch = false;
             self.buffer.clear();
             self.buffer_accent_count = 0;
-        } else if !"<>-=~|_".contains(*character)
+        } else if !"<>-=~|_".contains(character)
             && !character.is_ascii_digit()
             && is_symbol(character)
         {
             self.is_current_word_bad = true;
-            self.buffer.push(*character);
+            self.buffer.push(character);
         }
     }
     fn ratio(&self) -> f32 {
@@ -332,11 +332,11 @@ struct CjkInvalidStopPlugin {
 }
 
 impl MessDetectorPlugin for CjkInvalidStopPlugin {
-    fn eligible(&self, character: &char) -> bool {
+    fn eligible(&self, character: char) -> bool {
         true
     }
-    fn feed(&mut self, character: &char) {
-        if "丅丄".contains(*character) {
+    fn feed(&mut self, character: char) {
+        if "丅丄".contains(character) {
             self.wrong_stop_count += 1;
             return;
         }
@@ -381,10 +381,10 @@ impl Default for ArchaicUpperLowerPlugin {
 }
 
 impl MessDetectorPlugin for ArchaicUpperLowerPlugin {
-    fn eligible(&self, character: &char) -> bool {
+    fn eligible(&self, character: char) -> bool {
         true
     }
-    fn feed(&mut self, character: &char) {
+    fn feed(&mut self, character: char) {
         if !(character.is_alphabetic() && is_case_variable(character))
             && self.character_count_since_last_sep > 0
         {
@@ -424,7 +424,7 @@ impl MessDetectorPlugin for ArchaicUpperLowerPlugin {
 
         self.character_count += 1;
         self.character_count_since_last_sep += 1;
-        self.last_alpha_seen = Some(*character);
+        self.last_alpha_seen = Some(character);
     }
     fn ratio(&self) -> f32 {
         if self.character_count == 0 {
@@ -466,8 +466,8 @@ pub(crate) fn mess_ratio(
         .enumerate()
     {
         for detector in &mut *detectors {
-            if detector.eligible(&ch) {
-                detector.feed(&ch);
+            if detector.eligible(ch) {
+                detector.feed(ch);
             }
         }
 

--- a/src/tests/cd.rs
+++ b/src/tests/cd.rs
@@ -56,8 +56,8 @@ fn test_alphabet_languages() {
         ("Ailem ve Ben Adım Ece ve on iki yaşındayım. Her sabah 7'de uyanırım, kahvaltımı yaparım ve okula giderim. Boş zamanlarımda bahçede kitap okumayı severim. Küçük bir erkek kardeşim var. Kardeşim üç yaşında ve resim yapmayı sever. Evde her gün top oynar ve şarkı söyler. Kardeşim ve ben makarna yemeyi severiz. Bazen mutfakta yemekleri biz hazırlarız.", false, Some(Language::Turkish)),
     ];
     for (input, ignore_non_latin, expected) in tests {
-        let characters = input.chars().collect::<Vec<char>>();
-        let languages = alphabet_languages(characters, ignore_non_latin);
+        let characters: Vec<char> = input.chars().collect();
+        let languages = alphabet_languages(&characters, ignore_non_latin);
         if expected.is_none() {
             assert_eq!(languages.len(), 0);
         } else {

--- a/src/tests/cd.rs
+++ b/src/tests/cd.rs
@@ -57,8 +57,7 @@ fn test_alphabet_languages() {
     ];
     for (input, ignore_non_latin, expected) in tests {
         let characters = input.chars().collect::<Vec<char>>();
-        let characters_2 = characters.iter().collect();
-        let languages = alphabet_languages(&characters_2, ignore_non_latin);
+        let languages = alphabet_languages(characters, ignore_non_latin);
         if expected.is_none() {
             assert_eq!(languages.len(), 0);
         } else {

--- a/src/tests/utils.rs
+++ b/src/tests/utils.rs
@@ -28,50 +28,50 @@ fn test_is_accentuated() {
         ('Ё', false),
     ];
     for test in &tests {
-        assert_eq!(is_accentuated(&test.0), test.1);
+        assert_eq!(is_accentuated(test.0), test.1);
     }
 }
 
 #[test]
 fn test_is_latin() {
-    assert!(!is_latin(&'я'));
-    assert!(is_latin(&'a'));
+    assert!(!is_latin('я'));
+    assert!(is_latin('a'));
 }
 
 #[test]
 fn test_is_cjk() {
-    assert!(!is_cjk(&'я'));
-    assert!(is_cjk(&'是'));
+    assert!(!is_cjk('я'));
+    assert!(is_cjk('是'));
 }
 
 #[test]
 fn test_is_hiragana() {
-    assert!(!is_hiragana(&'是'));
-    assert!(is_hiragana(&'お'));
+    assert!(!is_hiragana('是'));
+    assert!(is_hiragana('お'));
 }
 
 #[test]
 fn test_is_katakana() {
-    assert!(!is_katakana(&'お'));
-    assert!(is_katakana(&'キ'));
+    assert!(!is_katakana('お'));
+    assert!(is_katakana('キ'));
 }
 
 #[test]
 fn test_is_hangul() {
-    assert!(!is_hangul(&'キ'));
-    assert!(is_hangul(&'ㅂ'));
+    assert!(!is_hangul('キ'));
+    assert!(is_hangul('ㅂ'));
 }
 
 #[test]
 fn test_is_thai() {
-    assert!(!is_thai(&'キ'));
-    assert!(is_thai(&'ย'));
+    assert!(!is_thai('キ'));
+    assert!(is_thai('ย'));
 }
 
 #[test]
 fn test_is_case_variable() {
-    assert!(!is_case_variable(&'#'));
-    assert!(is_case_variable(&'я'));
+    assert!(!is_case_variable('#'));
+    assert!(is_case_variable('я'));
 }
 
 #[test]
@@ -92,7 +92,7 @@ fn test_unicode_range() {
             ('ͽ', "Greek and Coptic"),
         ];
         for test in &tests {
-            assert_eq!(unicode_range(&test.0), Some(test.1));
+            assert_eq!(unicode_range(test.0), Some(test.1));
         }
     }
 }
@@ -115,7 +115,7 @@ fn test_is_ascii() {
 fn test_remove_accent() {
     let tests = [('á', 'a'), ('É', 'E'), ('Ǔ', 'U'), ('↓', '↓')];
     for test in &tests {
-        assert_eq!(remove_accent(&test.0), test.1);
+        assert_eq!(remove_accent(test.0), test.1);
     }
 }
 
@@ -133,7 +133,7 @@ fn test_range_scan() {
 fn test_is_punctuation() {
     let tests = [('!', true), ('?', true), ('a', false), (':', true)];
     for test in &tests {
-        assert_eq!(is_punctuation(&test.0), test.1);
+        assert_eq!(is_punctuation(test.0), test.1);
     }
 }
 
@@ -141,7 +141,7 @@ fn test_is_punctuation() {
 fn test_is_symbol() {
     let tests = [('+', true), ('∑', true), ('a', false), ('я', false)];
     for test in &tests {
-        assert_eq!(is_symbol(&test.0), test.1);
+        assert_eq!(is_symbol(test.0), test.1);
     }
 }
 
@@ -149,7 +149,7 @@ fn test_is_symbol() {
 fn test_is_emoticon() {
     let tests = [('🙂', true), ('∑', false), ('😂', true), ('я', false)];
     for test in &tests {
-        assert_eq!(is_emoticon(&test.0), test.1);
+        assert_eq!(is_emoticon(test.0), test.1);
     }
 }
 
@@ -157,7 +157,7 @@ fn test_is_emoticon() {
 fn test_is_separator() {
     let tests = [(' ', true), ('a', false), ('!', true), ('я', false)];
     for test in &tests {
-        assert_eq!(is_separator(&test.0), test.1);
+        assert_eq!(is_separator(test.0), test.1);
     }
 }
 
@@ -165,7 +165,7 @@ fn test_is_separator() {
 fn test_is_unprintable() {
     let tests = [(' ', false), ('a', false), ('!', false), ('\u{0000}', true)];
     for test in &tests {
-        assert_eq!(is_unprintable(&test.0), test.1);
+        assert_eq!(is_unprintable(test.0), test.1);
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -21,13 +21,13 @@ use unic::ucd::{GeneralCategory, Name};
 // if character category is exactly one of categories_exact or
 // character is from range which has name, contains one of ranges_partial
 fn in_category(
-    character: &char,
+    character: char,
     categories_exact: &[&str],
     categories_partial: &[&str],
     ranges_partial: &[&str],
 ) -> bool {
     // unicode category part
-    let category = GeneralCategory::of(*character).abbr_name();
+    let category = GeneralCategory::of(character).abbr_name();
     if categories_exact.contains(&category)
         || categories_partial.iter().any(|&cp| category.contains(cp))
     {
@@ -43,8 +43,8 @@ fn in_category(
 }
 
 // check if character description contains at least one of patterns
-fn in_description(character: &char, patterns: &[&str]) -> bool {
-    Name::of(*character)
+fn in_description(character: char, patterns: &[&str]) -> bool {
+    Name::of(character)
         .map(|description| {
             patterns
                 .iter()
@@ -56,37 +56,37 @@ fn in_description(character: &char, patterns: &[&str]) -> bool {
 #[cached(
     type = "UnboundCache<char, bool>",
     create = "{ UnboundCache::with_capacity(*UTF8_MAXIMAL_ALLOCATION) }",
-    convert = r#"{ *character }"#
+    convert = r#"{ character }"#
 )]
-pub(crate) fn is_punctuation(character: &char) -> bool {
+pub(crate) fn is_punctuation(character: char) -> bool {
     in_category(character, &[], &["P"], &["Punctuation"])
 }
 
 #[cached(
     type = "UnboundCache<char, bool>",
     create = "{ UnboundCache::with_capacity(*UTF8_MAXIMAL_ALLOCATION) }",
-    convert = r#"{ *character }"#
+    convert = r#"{ character }"#
 )]
-pub(crate) fn is_symbol(character: &char) -> bool {
+pub(crate) fn is_symbol(character: char) -> bool {
     in_category(character, &[], &["N", "S"], &["Forms"])
 }
 
 #[cached(
     type = "UnboundCache<char, bool>",
     create = "{ UnboundCache::with_capacity(*UTF8_MAXIMAL_ALLOCATION) }",
-    convert = r#"{ *character }"#
+    convert = r#"{ character }"#
 )]
-pub(crate) fn is_emoticon(character: &char) -> bool {
+pub(crate) fn is_emoticon(character: char) -> bool {
     in_category(character, &[], &[], &["Emoticons"])
 }
 
 #[cached(
     type = "UnboundCache<char, bool>",
     create = "{ UnboundCache::with_capacity(*UTF8_MAXIMAL_ALLOCATION) }",
-    convert = r#"{ *character }"#
+    convert = r#"{ character }"#
 )]
-pub(crate) fn is_separator(character: &char) -> bool {
-    if character.is_whitespace() || ['｜', '+', '<', '>'].contains(character) {
+pub(crate) fn is_separator(character: char) -> bool {
+    if character.is_whitespace() || ['｜', '+', '<', '>'].contains(&character) {
         return true;
     }
     in_category(character, &["Po", "Pd", "Pc"], &["Z"], &[])
@@ -95,21 +95,21 @@ pub(crate) fn is_separator(character: &char) -> bool {
 #[cached(
     type = "UnboundCache<char, bool>",
     create = "{ UnboundCache::with_capacity(*UTF8_MAXIMAL_ALLOCATION) }",
-    convert = r#"{ *character }"#
+    convert = r#"{ character }"#
 )]
-pub(crate) fn is_unprintable(character: &char) -> bool {
+pub(crate) fn is_unprintable(character: char) -> bool {
     !character.is_whitespace()
         && !character.is_ascii_graphic()
-        && !['\x1A', '\u{FEFF}'].contains(character)
+        && !['\x1A', '\u{FEFF}'].contains(&character)
         && in_category(character, &["Cc"], &[], &["Control character"])
 }
 
 #[cached(
     type = "UnboundCache<char, bool>",
     create = "{ UnboundCache::with_capacity(*UTF8_MAXIMAL_ALLOCATION) }",
-    convert = r#"{ *character }"#
+    convert = r#"{ character }"#
 )]
-pub(crate) fn is_accentuated(character: &char) -> bool {
+pub(crate) fn is_accentuated(character: char) -> bool {
     let patterns = [
         "WITH GRAVE",
         "WITH ACUTE",
@@ -124,9 +124,9 @@ pub(crate) fn is_accentuated(character: &char) -> bool {
 #[cached(
     type = "UnboundCache<char, bool>",
     create = "{ UnboundCache::with_capacity(*UTF8_MAXIMAL_ALLOCATION) }",
-    convert = r#"{ *character }"#
+    convert = r#"{ character }"#
 )]
-pub(crate) fn is_latin(character: &char) -> bool {
+pub(crate) fn is_latin(character: char) -> bool {
     let patterns = ["LATIN"];
     in_description(character, &patterns)
 }
@@ -134,9 +134,9 @@ pub(crate) fn is_latin(character: &char) -> bool {
 #[cached(
     type = "UnboundCache<char, bool>",
     create = "{ UnboundCache::with_capacity(*UTF8_MAXIMAL_ALLOCATION) }",
-    convert = r#"{ *character }"#
+    convert = r#"{ character }"#
 )]
-pub(crate) fn is_cjk(character: &char) -> bool {
+pub(crate) fn is_cjk(character: char) -> bool {
     let patterns = ["CJK"];
     in_description(character, &patterns)
 }
@@ -144,9 +144,9 @@ pub(crate) fn is_cjk(character: &char) -> bool {
 #[cached(
     type = "UnboundCache<char, bool>",
     create = "{ UnboundCache::with_capacity(*UTF8_MAXIMAL_ALLOCATION) }",
-    convert = r#"{ *character }"#
+    convert = r#"{ character }"#
 )]
-pub(crate) fn is_hiragana(character: &char) -> bool {
+pub(crate) fn is_hiragana(character: char) -> bool {
     let patterns = ["HIRAGANA"];
     in_description(character, &patterns)
 }
@@ -154,9 +154,9 @@ pub(crate) fn is_hiragana(character: &char) -> bool {
 #[cached(
     type = "UnboundCache<char, bool>",
     create = "{ UnboundCache::with_capacity(*UTF8_MAXIMAL_ALLOCATION) }",
-    convert = r#"{ *character }"#
+    convert = r#"{ character }"#
 )]
-pub(crate) fn is_katakana(character: &char) -> bool {
+pub(crate) fn is_katakana(character: char) -> bool {
     let patterns = ["KATAKANA"];
     in_description(character, &patterns)
 }
@@ -164,9 +164,9 @@ pub(crate) fn is_katakana(character: &char) -> bool {
 #[cached(
     type = "UnboundCache<char, bool>",
     create = "{ UnboundCache::with_capacity(*UTF8_MAXIMAL_ALLOCATION) }",
-    convert = r#"{ *character }"#
+    convert = r#"{ character }"#
 )]
-pub(crate) fn is_hangul(character: &char) -> bool {
+pub(crate) fn is_hangul(character: char) -> bool {
     let patterns = ["HANGUL"];
     in_description(character, &patterns)
 }
@@ -174,14 +174,14 @@ pub(crate) fn is_hangul(character: &char) -> bool {
 #[cached(
     type = "UnboundCache<char, bool>",
     create = "{ UnboundCache::with_capacity(*UTF8_MAXIMAL_ALLOCATION) }",
-    convert = r#"{ *character }"#
+    convert = r#"{ character }"#
 )]
-pub(crate) fn is_thai(character: &char) -> bool {
+pub(crate) fn is_thai(character: char) -> bool {
     let patterns = ["THAI"];
     in_description(character, &patterns)
 }
 
-pub(crate) fn is_case_variable(character: &char) -> bool {
+pub(crate) fn is_case_variable(character: char) -> bool {
     character.is_lowercase() != character.is_uppercase()
 }
 
@@ -192,8 +192,8 @@ pub(crate) fn is_unicode_range_secondary(range_name: &str) -> bool {
 }
 
 // Retrieve the Unicode range official name from a single character
-pub(crate) fn unicode_range(character: &char) -> Option<&'static str> {
-    let char_code = *character as u32;
+pub(crate) fn unicode_range(character: char) -> Option<&'static str> {
+    let char_code = character as u32;
     UNICODE_RANGES_COMBINED
         .iter()
         .find(|&(_, range)| range.contains(&char_code))
@@ -206,17 +206,17 @@ pub(crate) fn range_scan(decoded_sequence: &str) -> HashSet<String> {
     result.extend(
         decoded_sequence
             .chars()
-            .filter_map(|ch| unicode_range(&ch).map(|r| r.to_string())),
+            .filter_map(|ch| unicode_range(ch).map(|r| r.to_string())),
     );
     result // decoded_sequence.chars().filter_map(|ch| unicode_range(&ch).map(|r| r.to_string())).collect()
 }
 
-pub(crate) fn remove_accent(ch: &char) -> char {
+pub(crate) fn remove_accent(ch: char) -> char {
     let mut base_char = None;
-    decompose_canonical(*ch, |c| {
+    decompose_canonical(ch, |c| {
         base_char.get_or_insert(c);
     });
-    base_char.map_or(*ch, |c| c)
+    base_char.map_or(ch, |c| c)
 }
 
 pub(crate) fn should_strip_sig_or_bom(_iana_encoding: &str) -> bool {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -46,8 +46,8 @@ fn in_category(
 }
 
 // check if character description contains at least one of patterns
-fn in_description(character: &char, patterns: &[&str]) -> bool {
-    Name::of(*character).is_some_and(|description| {
+fn in_description(character: char, patterns: &[&str]) -> bool {
+    Name::of(character).is_some_and(|description| {
         patterns
             .iter()
             .any(|&s| description.to_string().contains(s))


### PR DESCRIPTION
Looking into the [`copied().copied()` issue](https://github.com/nickspring/charset-normalizer-rs/blob/1e2e6b59ccd12a89a70124019cf36718b99996e9/src/cd.rs#L97), and a clippy lint arguing that using raw char copy rather than a reference could be more efficient and faster.

short explanation for [trivially_copy_pass_by_ref](https://rust-lang.github.io/rust-clippy/rust-1.71.0/index.html#trivially_copy_pass_by_ref)
> Checks for functions taking arguments by reference, where the argument type is Copy and small enough to be more efficient to always pass by value.

Most changes directly deal with the type conversion (`&char` into `char`) or the downstream and upstream consequences of that. It also deals with the downstream changes enabled by that.